### PR TITLE
fix/issue-with-heap-corruption-is-fixed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-concurrent-vec"
-version = "1.3.0"
+version = "1.4.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "An efficient, convenient and lightweight grow-only, read and write concurrent collection."
@@ -10,7 +10,7 @@ keywords = ["concurrency", "vec", "data-structures", "atomic", "lock-free"]
 categories = ["data-structures", "concurrency", "rust-patterns"]
 
 [dependencies]
-orx-concurrent-bag = "1.9"
+orx-concurrent-bag = "1.10"
 orx-fixed-vec = "2.7"
 orx-pinned-vec = "2.7"
 orx-split-vec = "2.8"

--- a/src/drop.rs
+++ b/src/drop.rs
@@ -1,0 +1,59 @@
+use orx_concurrent_vec::*;
+use test_case::test_matrix;
+
+#[test_matrix(
+    [
+        FixedVec::new(100000),
+        SplitVec::with_doubling_growth_and_fragments_capacity(32),
+        SplitVec::with_recursive_growth_and_fragments_capacity(32),
+        SplitVec::with_linear_growth_and_fragments_capacity(10, 64),
+    ],
+    [124, 348, 1024, 2587, 42578]
+)]
+fn dropped_as_bag<P: PinnedVec<String>>(pinned_vec: P, len: usize) {
+    let num_threads = 4;
+    let num_items_per_thread = len / num_threads;
+
+    let bag = fill_bag(pinned_vec, len);
+
+    assert_eq!(bag.len(), num_threads * num_items_per_thread);
+}
+
+#[test_matrix(
+    [
+        FixedVec::new(100000),
+        SplitVec::with_doubling_growth_and_fragments_capacity(32),
+        SplitVec::with_recursive_growth_and_fragments_capacity(32),
+        SplitVec::with_linear_growth_and_fragments_capacity(10, 64),
+    ],
+    [124, 348, 1024, 2587, 42578]
+)]
+fn dropped_after_into_inner<P: PinnedVec<String>>(pinned_vec: P, len: usize) {
+    let num_threads = 4;
+    let num_items_per_thread = len / num_threads;
+
+    let bag = fill_bag(pinned_vec, len);
+
+    let inner = bag.into_inner();
+    assert_eq!(inner.len(), num_threads * num_items_per_thread);
+}
+
+fn fill_bag<P: PinnedVec<String>>(pinned_vec: P, len: usize) -> ConcurrentVec<String, P> {
+    let num_threads = 4;
+    let num_items_per_thread = len / num_threads;
+
+    let bag: ConcurrentVec<_, _> = pinned_vec.into();
+    let con_bag = &bag;
+    std::thread::scope(move |s| {
+        for _ in 0..num_threads {
+            s.spawn(move || {
+                for value in 0..num_items_per_thread {
+                    let new_value = format!("from-thread-{}", value);
+                    con_bag.push(new_value);
+                }
+            });
+        }
+    });
+
+    bag
+}


### PR DESCRIPTION
The fix is applied in orx-concurrent-bag. This PR involves updating the dependency version. Further, relevant test coverage is increased.