### PR TITLE
PinnedConcurrentCol migration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,19 +1,20 @@
 [package]
 name = "orx-concurrent-vec"
-version = "1.4.0"
+version = "1.5.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
-description = "An efficient, convenient and lightweight grow-only, read and write concurrent collection."
+description = "An efficient, convenient and lightweight grow-only read & write concurrent data structure allowing high performance concurrent collection."
 license = "MIT"
 repository = "https://github.com/orxfun/orx-concurrent-vec/"
 keywords = ["concurrency", "vec", "data-structures", "atomic", "lock-free"]
 categories = ["data-structures", "concurrency", "rust-patterns"]
 
 [dependencies]
-orx-concurrent-bag = "1.10"
-orx-fixed-vec = "2.7"
-orx-pinned-vec = "2.7"
-orx-split-vec = "2.8"
+orx-concurrent-bag = "1.11"
+orx-fixed-vec = "2.8"
+orx-pinned-concurrent-col = "1.0"
+orx-pinned-vec = "2.8"
+orx-split-vec = "2.9"
 
 [dev-dependencies]
 criterion = "0.5.1"

--- a/README.md
+++ b/README.md
@@ -3,15 +3,14 @@
 [![orx-concurrent-vec crate](https://img.shields.io/crates/v/orx-concurrent-vec.svg)](https://crates.io/crates/orx-concurrent-vec)
 [![orx-concurrent-vec documentation](https://docs.rs/orx-concurrent-vec/badge.svg)](https://docs.rs/orx-concurrent-vec)
 
-An efficient, convenient and lightweight grow-only and read-and-write concurrent collection.
+An efficient, convenient and lightweight grow-only read & write concurrent data structure allowing high performance concurrent collection.
 
-* **convenient**: `ConcurrentVec` can safely be shared among threads simply as a shared reference. Further, it is a wrapper around any [`PinnedVec`](https://crates.io/crates/orx-pinned-vec) implementation adding concurrent safety guarantees. Underlying pinned vector of `Option<T>` and concurrent vec of `T` can be converted to each other back and forth without any cost (see <a href="#section-construction-and-conversions">construction and conversions</a>).
-* **lightweight**: This crate takes a simplistic approach built on pinned vector guarantees which leads to concurrent programs with few dependencies and small binaries (see <a href="#section-approach-and-safety">approach and safety</a> for details).
-* **efficient**: `ConcurrentBag` is a grow only collection with immutable elements making use of atomic primitives. This leads to efficient growth and lock-free reading. You may see the details in <a href="#section-benchmarks">benchmarks</a> and further <a href="#section-performance-notes">performance notes</a>.
+* **convenient**: `ConcurrentVec` can safely be shared among threads simply as a shared reference. It is a [`PinnedConcurrentCol`](https://crates.io/crates/orx-pinned-concurrent-col) with a special concurrent state implementation. Underlying [`PinnedVec`](https://crates.io/crates/orx-pinned-vec) and concurrent bag can be converted back and forth to each other.
+* **efficient**: `ConcurrentVec` is a lock free structure making use of a few atomic primitives, this leads to high performance concurrent growth. You may see the details in <a href="#section-benchmarks">benchmarks</a> and further <a href="#section-performance-notes">performance notes</a>.
 
-Note that `ConcurrentVec` is a **read and write** collection. When we only need to collect results concurrently without reading, [`ConcurrentBag`](https://crates.io/crates/orx-concurrent-bag) is preferable due to its performance optimizations. Having almost identical api, switching between `ConcurrentVec` and `ConcurrentBag` is straightforward.
+Note that `ConcurrentVec` is a read & write collection with the cost to store values wrapped with an optional and initializing memory on allocation. See [`ConcurrentBag`](https://crates.io/crates/orx-concurrent-bag) for a write only and a more performant variant. Having almost identical api, switching between `ConcurrentVec` and `ConcurrentBag` is straightforward.
 
-# A. Examples
+## Examples
 
 The main feature of `ConcurrentVec` compared to concurrent bag is to enable safe reading while providing efficient growth. It is convenient to share the concurrent vector among threads. `std::sync::Arc` can be used; however, it is not required as demonstrated below.
 
@@ -100,89 +99,7 @@ assert_eq!(measurements.len(), 100);
 assert_eq!(metrics.len(), 10);
 ```
 
-<div id="section-approach-and-safety"></div>
-
-# B. Approach and Safety
-
-`ConcurrentVec` is a wrapper around the `ConcurrentBag` with a focus to enable safe concurrent reading while concurrent bag focuses on efficient growth. Details of the approach and growth related safety guarantees can be found [here](https://docs.rs/orx-concurrent-bag/latest/orx_concurrent_bag/#section-approach-and-safety).
-
-In order to add safe concurrent reading feature to the concurrent bag, the following simple approach is taken:
-* When `ConcurrentBag` allocates to grow, it does not initialize the memory of positions which are less than the length (as common in dynamic size vectors). Since reading from a concurrent bag only happens after the consuming `into_inner` method, this is perfectly fine. Read methods such as `get(index)` and `iter()` are available; however, unsafe, due to the possibility of the following sequence of events:
-  * `bag.push('a')` is called from thread#1.
-  * `bag` atomically increases the `len` to 1.
-  * thread#2 calls `bag.get(0)` which is now in bounds.
-  * thread#2 receives uninitialized value which is an undefined behavior (UB).
-  * thread#1 completes writing `'a'` to the 0-th position (one moment too late).
-* `ConcurrentVec` prevents this as follows:
-  * Instead of `T`, elements of a concurrent vector are stored as `Option<T>`.
-  * When `ConcurrentVec` allocates, it initializes all new positions as `None`.
-* Read methods such as `get` or `iter` skips in-bounds but `None` elements. These are the elements which are reserved by some threads; however, the process of writing them is not completed yet.
-* Further, elements already pushed to the concurrent vector are immutable. In other words, if the value at a position is of `Some` variant, it will never change.
-* Therefore, it is possible to read already pushed elements without a race condition.
-
-<div id="section-benchmarks"></div>
-
-# C. Benchmarks
-
-## Performance with `push`
-
-*You may find the details of the benchmarks at [benches/collect_with_push.rs](https://github.com/orxfun/orx-concurrent-vec/blob/main/benches/collect_with_push.rs).*
-
-In the experiment, `rayon`s parallel iterator and `ConcurrentVec`s `push` method are used to collect results from multiple threads.
-
-```rust ignore
-// reserve and push one position at a time
-for j in 0..num_items_per_thread {
-    bag_ref.push(i * 1000 + j);
-}
-```
-
-* We observe that rayon is significantly faster when the output is very small (`i32` in this experiment).
-* As the output gets larger and copies become costlier (`[i32; 32]` here), `ConcurrentVec::push` starts to perform equivalent to or faster than rayon.
-* Among the `ConcurrentVec` variants, `Linear` and `Fixed` variants perform faster than the `Doubling` variant:
-  * Here we observe the cost of memory initialization immediately on allocation. Since `Doubling` variant allocates more, initialization has a greater impact.
-  * `ConcurrentBag` does not perform this operation and it leads to a very high performance concurrent collection. Further, the impact of the underlying pinned vector type is insignificant. Therefore, it is a better choice when we only write results concurrently.
-  * The main goal of `ConcurrentVec`, on the other hand, is to enable safe reading while the vector concurrently grows, and it must be preferred in these situations over making unsafe calls.
-  * Having almost identical api, switching between bag and vec is straightforward.
-
-The issue leading to poor performance in the *small data & little work* situation can be avoided by using `extend` method in such cases. You may see its impact in the succeeding subsections and related reasons in the <a href="#section-performance-notes">performance notes</a>.
-
-<img src="https://raw.githubusercontent.com/orxfun/orx-concurrent-vec/main/docs/img/bench_collect_with_push.PNG" alt="https://raw.githubusercontent.com/orxfun/orx-concurrent-vec/main/docs/img/bench_collect_with_push.PNG" />
-
-## Performance of `extend`
-
-*You may find the details of the benchmarks at [benches/collect_with_extend.rs](https://github.com/orxfun/orx-concurrent-vec/blob/main/benches/collect_with_extend.rs).*
-
-The only difference in this follow up experiment is that we use `extend` rather than `push` with `ConcurrentVec`. The expectation is that this approach will solve the performance degradation due to false sharing in the *small data & little work* situation.
-
-```rust ignore
-// reserve num_items_per_thread positions at a time
-// and then push as the iterator yields
-let iter = (0..num_items_per_thread).map(|j| i * 100000 + j);
-bag_ref.extend(iter);
-```
-
-<img src="https://raw.githubusercontent.com/orxfun/orx-concurrent-vec/main/docs/img/bench_collect_with_extend.PNG" alt="https://raw.githubusercontent.com/orxfun/orx-concurrent-vec/main/docs/img/bench_collect_with_extend.PNG" />
-
-Note that we do not need to have perfect information on the number of items to be pushed per thread to get the benefits of `extend`, we can simply `step_by`. Extending by `batch_size` elements will already prevent the dramatic performance degradation provided that `batch_size` elements exceed a cache line.
-
-```rust ignore
-// reserve batch_size positions at a time
-// and then push as the iterator yields
-for j in (0..num_items_per_thread).step_by(batch_size) {
-    let iter = (j..(j + batch_size)).map(|j| i * 100000 + j);
-    bag_ref.extend(iter);
-}
-```
-
-<div id="section-performance-notes"></div>
-
-# D. Performance Notes
-
-`ConcurrentVec` is an efficient read-and-write collection. However, it is important to avoid false sharing risk which might lead to a significant performance degradation. Details can be read [here](https://docs.rs/orx-concurrent-bag/latest/orx_concurrent_bag/#section-performance-notes).
-<div id="section-construction-and-conversions"></div>
-
-# E. `From` | `into_inner`
+### Construction
 
 `ConcurrentVec` can be constructed by wrapping any pinned vector; i.e., `ConcurrentVec<T>` implements `From<P: PinnedVec<Option<T>>>`.
 Likewise, a concurrent vector can be unwrapped to get the underlying pinned vector with `into_inner` method.
@@ -222,6 +139,78 @@ let split_vec: SplitVec<Option<i32>> = (0..1024).map(Some).collect();
 let con_vec: ConcurrentVec<_> = split_vec.into();
 ```
 
-# License
+## Concurrent State and Properties
+
+The concurrent state is modeled simply by an atomic length. Combination of this state and `PinnedConcurrentCol` leads to the following properties:
+* Writing to a position of the collection does not block other writes, multiple writes can happen concurrently.
+* Each position is written exactly once.
+* ⟹ no write & write race condition exists.
+* Only one growth can happen at a given time.
+* Underlying pinned vector is always valid and can be taken out any time by `into_inner(self)`.
+* Reading a position while its being written will yield `None` and will be omitted.
+
+<div id="section-benchmarks"></div>
+
+## Benchmarks
+
+### Performance with `push`
+
+*You may find the details of the benchmarks at [benches/collect_with_push.rs](https://github.com/orxfun/orx-concurrent-vec/blob/main/benches/collect_with_push.rs).*
+
+In the experiment, `rayon`s parallel iterator and `ConcurrentVec`s `push` method are used to collect results from multiple threads.
+
+```rust ignore
+// reserve and push one position at a time
+for j in 0..num_items_per_thread {
+    bag_ref.push(i * 1000 + j);
+}
+```
+
+* We observe that rayon is significantly faster when the output is very small (`i32` in this experiment).
+* As the output gets larger and copies become costlier (`[i32; 32]` here), `ConcurrentVec::push` starts to perform equivalent to or faster than rayon.
+* Among the `ConcurrentVec` variants, `Linear` and `Fixed` variants perform faster than the `Doubling` variant:
+  * Here we observe the cost of memory initialization immediately on allocation. Since `Doubling` variant allocates more, initialization has a greater impact.
+  * `ConcurrentBag` does not perform this operation and it leads to a very high performance concurrent collection. Further, the impact of the underlying pinned vector type is insignificant. Therefore, it is a better choice when we only write results concurrently.
+  * The main goal of `ConcurrentVec`, on the other hand, is to enable safe reading while the vector concurrently grows, and it must be preferred in these situations over making unsafe calls.
+  * Having almost identical api, switching between bag and vec is straightforward.
+
+The issue leading to poor performance in the *small data & little work* situation can be avoided by using `extend` method in such cases. You may see its impact in the succeeding subsections and related reasons in the <a href="#section-performance-notes">performance notes</a>.
+
+<img src="https://raw.githubusercontent.com/orxfun/orx-concurrent-vec/main/docs/img/bench_collect_with_push.PNG" alt="https://raw.githubusercontent.com/orxfun/orx-concurrent-vec/main/docs/img/bench_collect_with_push.PNG" />
+
+### Performance of `extend`
+
+*You may find the details of the benchmarks at [benches/collect_with_extend.rs](https://github.com/orxfun/orx-concurrent-vec/blob/main/benches/collect_with_extend.rs).*
+
+The only difference in this follow up experiment is that we use `extend` rather than `push` with `ConcurrentVec`. The expectation is that this approach will solve the performance degradation due to false sharing in the *small data & little work* situation.
+
+```rust ignore
+// reserve num_items_per_thread positions at a time
+// and then push as the iterator yields
+let iter = (0..num_items_per_thread).map(|j| i * 100000 + j);
+bag_ref.extend(iter);
+```
+
+<img src="https://raw.githubusercontent.com/orxfun/orx-concurrent-vec/main/docs/img/bench_collect_with_extend.PNG" alt="https://raw.githubusercontent.com/orxfun/orx-concurrent-vec/main/docs/img/bench_collect_with_extend.PNG" />
+
+Note that we do not need to have perfect information on the number of items to be pushed per thread to get the benefits of `extend`, we can simply `step_by`. Extending by `batch_size` elements will already prevent the dramatic performance degradation provided that `batch_size` elements exceed a cache line.
+
+```rust ignore
+// reserve batch_size positions at a time
+// and then push as the iterator yields
+for j in (0..num_items_per_thread).step_by(batch_size) {
+    let iter = (j..(j + batch_size)).map(|j| i * 100000 + j);
+    bag_ref.extend(iter);
+}
+```
+
+<div id="section-performance-notes"></div>
+
+### Performance Notes
+
+`ConcurrentVec` is an efficient read-and-write collection. However, it is important to avoid false sharing risk which might lead to a significant performance degradation. Details can be read [here](https://docs.rs/orx-concurrent-bag/latest/orx_concurrent_bag/#section-performance-notes).
+<div id="section-construction-and-conversions"></div>
+
+## License
 
 This library is licensed under MIT license. See LICENSE for details.

--- a/src/new.rs
+++ b/src/new.rs
@@ -1,0 +1,79 @@
+use crate::vec::ConcurrentVec;
+use orx_fixed_vec::{FixedVec, PinnedVec};
+use orx_split_vec::{Doubling, Linear, Recursive, SplitVec};
+
+impl<T> Default for ConcurrentVec<T, SplitVec<Option<T>, Doubling>> {
+    /// Creates a new concurrent bag by creating and wrapping up a new [`SplitVec<Option<T>, Doubling>`](https://docs.rs/orx-split-vec/latest/orx_split_vec/struct.Doubling.html) as the underlying storage.
+    fn default() -> Self {
+        Self::with_doubling_growth()
+    }
+}
+
+impl<T> ConcurrentVec<T, SplitVec<Option<T>, Doubling>> {
+    /// Creates a new concurrent bag by creating and wrapping up a new [`SplitVec<Option<T>, Doubling>`](https://docs.rs/orx-split-vec/latest/orx_split_vec/struct.Doubling.html) as the underlying storage.
+    pub fn new() -> Self {
+        Self::with_doubling_growth()
+    }
+
+    /// Creates a new concurrent bag by creating and wrapping up a new [`SplitVec<Option<T>, Doubling>`](https://docs.rs/orx-split-vec/latest/orx_split_vec/struct.Doubling.html) as the underlying storage.
+    pub fn with_doubling_growth() -> Self {
+        Self::new_from_pinned(SplitVec::with_doubling_growth_and_fragments_capacity(32))
+    }
+}
+
+impl<T> ConcurrentVec<T, SplitVec<Option<T>, Recursive>> {
+    /// Creates a new concurrent bag by creating and wrapping up a new [`SplitVec<Option<T>, Recursive>`](https://docs.rs/orx-split-vec/latest/orx_split_vec/struct.Recursive.html) as the underlying storage.
+    pub fn with_recursive_growth() -> Self {
+        Self::new_from_pinned(SplitVec::with_recursive_growth_and_fragments_capacity(32))
+    }
+}
+
+impl<T> ConcurrentVec<T, SplitVec<Option<T>, Linear>> {
+    /// Creates a new concurrent bag by creating and wrapping up a new [`SplitVec<Option<T>, Linear>`](https://docs.rs/orx-split-vec/latest/orx_split_vec/struct.Linear.html) as the underlying storage.
+    ///
+    /// * Each fragment of the split vector will have a capacity of  `2 ^ constant_fragment_capacity_exponent`.
+    /// * Further, fragments collection of the split vector will have a capacity of `fragments_capacity` on initialization.
+    ///
+    /// This leads to a [`orx_pinned_concurrent_col::PinnedConcurrentCol::maximum_capacity`] of `fragments_capacity * 2 ^ constant_fragment_capacity_exponent`.
+    ///
+    /// Whenever this capacity is not sufficient, fragments capacity can be increased by using the  [`orx_pinned_concurrent_col::PinnedConcurrentCol::reserve_maximum_capacity`] method.
+    pub fn with_linear_growth(
+        constant_fragment_capacity_exponent: usize,
+        fragments_capacity: usize,
+    ) -> Self {
+        Self::new_from_pinned(SplitVec::with_linear_growth_and_fragments_capacity(
+            constant_fragment_capacity_exponent,
+            fragments_capacity,
+        ))
+    }
+}
+
+impl<T> ConcurrentVec<T, FixedVec<Option<T>>> {
+    /// Creates a new concurrent bag by creating and wrapping up a new [`FixedVec<Option<T>>`](https://docs.rs/orx-fixed-vec/latest/orx_fixed_vec/) as the underlying storage.
+    ///
+    /// # Safety
+    ///
+    /// Note that a `FixedVec` cannot grow; i.e., it has a hard upper bound on the number of elements it can hold, which is the `fixed_capacity`.
+    ///
+    /// Pushing to the vector beyond this capacity leads to "out-of-capacity" error.
+    ///
+    /// This maximum capacity can be accessed by [`orx_pinned_concurrent_col::PinnedConcurrentCol::capacity`] or [`orx_pinned_concurrent_col::PinnedConcurrentCol::maximum_capacity`] methods.
+    pub fn with_fixed_capacity(fixed_capacity: usize) -> Self {
+        Self::new_from_pinned(FixedVec::new(fixed_capacity))
+    }
+}
+
+// from
+impl<T, P> From<P> for ConcurrentVec<T, P>
+where
+    P: PinnedVec<Option<T>>,
+{
+    /// `ConcurrentVec<Option<T>>` uses any `PinnedVec<T>` implementation as the underlying storage.
+    ///
+    /// Therefore, without a cost
+    /// * `ConcurrentVec<T>` can be constructed from any `PinnedVec<T>`, and
+    /// * the underlying `PinnedVec<T>` can be obtained by `ConcurrentVec::into_inner(self)` method.
+    fn from(pinned_vec: P) -> Self {
+        Self::new_from_pinned(pinned_vec)
+    }
+}

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -1,16 +1,14 @@
 use orx_concurrent_bag::ConcurrentBag;
-use orx_fixed_vec::{FixedVec, PinnedVec, PinnedVecGrowthError};
-use orx_split_vec::{Doubling, Linear, SplitVec};
+use orx_pinned_vec::PinnedVec;
+use orx_split_vec::{Doubling, SplitVec};
+use std::ops::{Deref, DerefMut};
 
-/// An efficient, convenient and lightweight grow-only read-and-write concurrent collection.
+/// An efficient, convenient and lightweight grow-only read & write concurrent data structure allowing high performance concurrent collection.
 ///
-/// * **convenient**: `ConcurrentVec` can safely be shared among threads simply as a shared reference. Further, it is a wrapper around any [`PinnedVec`](https://crates.io/crates/orx-pinned-vec) implementation adding concurrent safety guarantees. Underlying pinned vector of `Option<T>` and concurrent vec of `T` can be converted to each other back and forth without any cost.
-/// * **lightweight**: This crate takes a simplistic approach built on pinned vector guarantees which leads to concurrent programs with few dependencies and small binaries.
-/// * **efficient**: `ConcurrentVec` is a lock free structure making use of a few atomic primitives, this leads to high performance growth.
+/// * **convenient**: `ConcurrentVec` can safely be shared among threads simply as a shared reference. It is a [`PinnedConcurrentCol`](https://crates.io/crates/orx-pinned-concurrent-col) with a special concurrent state implementation. Underlying [`PinnedVec`](https://crates.io/crates/orx-pinned-vec) and concurrent bag can be converted back and forth to each other.
+/// * **efficient**: `ConcurrentVec` is a lock free structure making use of a few atomic primitives, this leads to high performance concurrent growth. You may see the details in <a href="#section-benchmarks">benchmarks</a> and further <a href="#section-performance-notes">performance notes</a>.
 ///
-/// Note that `ConcurrentVec` is closely related to [`ConcurrentBag`](https://crates.io/crates/orx-concurrent-bag) with the following differences:
-/// * `ConcurrentBag` is a write-only and grow-only concurrent collection which internally stores elements directly as `T`,
-/// * `ConcurrentVec` is a read-and-write and grow-only concurrent collection which internally stores elements directly as `Option<T>`.
+/// Note that `ConcurrentVec` is a read & write collection with the cost to store values wrapped with an optional and initializing memory on allocation. See [`ConcurrentBag`](https://crates.io/crates/orx-concurrent-bag) for a write only and a more performant variant. Having almost identical api, switching between `ConcurrentVec` and `ConcurrentBag` is straightforward.
 ///
 /// # Examples
 ///
@@ -101,6 +99,57 @@ use orx_split_vec::{Doubling, Linear, SplitVec};
 /// assert_eq!(measurements.len(), 100);
 /// assert_eq!(metrics.len(), 10);
 /// ```
+///
+/// ## Construction
+///
+/// `ConcurrentVec` can be constructed by wrapping any pinned vector; i.e., `ConcurrentVec<T>` implements `From<P: PinnedVec<Option<T>>>`.
+/// Likewise, a concurrent vector can be unwrapped without any cost to the underlying pinned vector with `into_inner` method.
+///
+/// Further, there exist `with_` methods to directly construct the concurrent bag with common pinned vector implementations.
+///
+/// ```rust
+/// use orx_concurrent_vec::*;
+///
+/// // default pinned vector -> SplitVec<T, Doubling>
+/// let bag: ConcurrentVec<char> = ConcurrentVec::new();
+/// let bag: ConcurrentVec<char> = Default::default();
+/// let bag: ConcurrentVec<char> = ConcurrentVec::with_doubling_growth();
+/// let bag: ConcurrentVec<char, SplitVec<Option<char>, Doubling>> = ConcurrentVec::with_doubling_growth();
+///
+/// let bag: ConcurrentVec<char> = SplitVec::new().into();
+/// let bag: ConcurrentVec<char, SplitVec<Option<char>, Doubling>> = SplitVec::new().into();
+///
+/// // SplitVec with [Linear](https://docs.rs/orx-split-vec/latest/orx_split_vec/struct.Linear.html) growth
+/// // each fragment will have capacity 2^10 = 1024
+/// // and the split vector can grow up to 32 fragments
+/// let bag: ConcurrentVec<char, SplitVec<Option<char>, Linear>> = ConcurrentVec::with_linear_growth(10, 32);
+/// let bag: ConcurrentVec<char, SplitVec<Option<char>, Linear>> = SplitVec::with_linear_growth_and_fragments_capacity(10, 32).into();
+///
+/// // [FixedVec](https://docs.rs/orx-fixed-vec/latest/orx_fixed_vec/) with fixed capacity.
+/// // Fixed vector cannot grow; hence, pushing the 1025-th element to this bag will cause a panic!
+/// let bag: ConcurrentVec<char, FixedVec<Option<char>>> = ConcurrentVec::with_fixed_capacity(1024);
+/// let bag: ConcurrentVec<char, FixedVec<Option<char>>> = FixedVec::new(1024).into();
+/// ```
+///
+/// Of course, the pinned vector to be wrapped does not need to be empty.
+///
+/// ```rust
+/// use orx_concurrent_vec::*;
+///
+/// let split_vec: SplitVec<Option<i32>> = (0..1024).map(Some).collect();
+/// let bag: ConcurrentVec<_> = split_vec.into();
+/// ```
+///
+/// # Concurrent State and Properties
+///
+/// The concurrent state is modeled simply by an atomic length.
+/// Combination of this state and `PinnedConcurrentCol` leads to the following properties:
+/// * Writing to the collection does not block. Multiple writes can happen concurrently.
+/// * Each position is written only and exactly once.
+/// * Only one growth can happen at a given time.
+/// * Underlying pinned vector can be extracted any time.
+/// * Safe reading is only possible after converting the bag into the underlying `PinnedVec`.
+/// No read & write race condition exists.
 #[derive(Debug)]
 pub struct ConcurrentVec<T, P = SplitVec<Option<T>, Doubling>>
 where
@@ -109,187 +158,46 @@ where
     bag: ConcurrentBag<Option<T>, P>,
 }
 
-// new
-impl<T> ConcurrentVec<T, SplitVec<Option<T>, Doubling>> {
-    /// Creates a new concurrent vector by creating and wrapping up a new `SplitVec<Option<T>, Doubling>` as the underlying storage.
-    pub fn with_doubling_growth() -> Self {
-        let pinned = SplitVec::with_doubling_growth_and_fragments_capacity(32);
-        Self::from_pinned_vec(pinned)
-    }
-
-    /// Creates a new concurrent vector by creating and wrapping up a new `SplitVec<Option<T>, Doubling>` as the underlying storage.
-    pub fn new() -> Self {
-        Self::with_doubling_growth()
-    }
-}
-
-impl<T> Default for ConcurrentVec<T, SplitVec<Option<T>, Doubling>> {
-    /// Creates a new concurrent vector by creating and wrapping up a new `SplitVec<Option<T>, Doubling>` as the underlying storage.
-    fn default() -> Self {
-        Self::with_doubling_growth()
-    }
-}
-
-impl<T> ConcurrentVec<T, SplitVec<Option<T>, Linear>> {
-    /// Creates a new concurrent vector by creating and wrapping up a new `SplitVec<Option<T>, Linear>` as the underlying storage.
-    ///
-    /// # Notes
-    ///
-    /// * `Linear` can be chosen over `Doubling` whenever memory efficiency is more critical since linear allocations lead to less waste.
-    /// * Choosing a small `constant_fragment_capacity_exponent` for a large bag to be filled might lead to too many growth calls.
-    /// * Furthermore, `Linear` growth strategy leads to a hard upper bound on the maximum capacity, please see the Safety section.
-    ///
-    /// # Safety
-    ///
-    /// `SplitVec<T, Linear>` can grow indefinitely (almost).
-    ///
-    /// However, `ConcurrentVec<T, SplitVec<T, Linear>>` has an upper bound on its capacity.
-    /// This capacity is computed as:
-    ///
-    /// ```rust ignore
-    /// 2usize.pow(constant_fragment_capacity_exponent) * fragments_capacity
-    /// ```
-    ///
-    /// For instance maximum capacity is 2^10 * 64 = 65536 when `constant_fragment_capacity_exponent=10` and `fragments_capacity=64`.
-    ///
-    /// Note that setting a relatively high and safe `fragments_capacity` is **not** costly, size of each element 2*usize.
-    ///
-    /// Pushing to the vector beyond this capacity leads to "out-of-capacity" error.
-    ///
-    /// This maximum capacity can be accessed by [`ConcurrentVec::maximum_capacity`] method.
-    pub fn with_linear_growth(
-        constant_fragment_capacity_exponent: usize,
-        fragments_capacity: usize,
-    ) -> Self {
-        let pinned = SplitVec::with_linear_growth_and_fragments_capacity(
-            constant_fragment_capacity_exponent,
-            fragments_capacity,
-        );
-        Self::from_pinned_vec(pinned)
-    }
-}
-
-impl<T> ConcurrentVec<T, FixedVec<Option<T>>> {
-    /// Creates a new concurrent vector by creating and wrapping up a new `FixedVec<Option<T>>` as the underlying storage.
-    ///
-    /// # Safety
-    ///
-    /// Note that a `FixedVec` cannot grow; i.e., it has a hard upper bound on the number of elements it can hold, which is the `fixed_capacity`.
-    ///
-    /// Pushing to the vector beyond this capacity leads to "out-of-capacity" error.
-    ///
-    /// This maximum capacity can be accessed by [`ConcurrentVec::maximum_capacity`] method.
-    pub fn with_fixed_capacity(fixed_capacity: usize) -> Self {
-        let pinned = FixedVec::new(fixed_capacity);
-        Self::from_pinned_vec(pinned)
-    }
-}
-
-impl<T, P> From<P> for ConcurrentVec<T, P>
-where
-    P: PinnedVec<Option<T>>,
-{
-    /// `ConcurrentVec<T>` is just a wrapper around `ConcurrentBag<Option<T>>` with additional guarantees to enable safe concurrent reading.
-    ///
-    /// Further, `ConcurrentBag<Option<T>>` wraps any `PinnedVec<Option<T>>` implementation.
-    ///
-    /// Therefore, without a cost
-    /// * `ConcurrentVec<T>` can be constructed from any `PinnedVec<Option<T>>`, and
-    /// * the underlying `PinnedVec<Option<T>>` can be obtained by `ConcurrentVec::into_inner(self)` method.
-    fn from(pinned: P) -> Self {
-        Self::from_pinned_vec(pinned)
-    }
-}
-
-impl<T, P> From<ConcurrentBag<Option<T>, P>> for ConcurrentVec<T, P>
-where
-    P: PinnedVec<Option<T>>,
-{
-    /// `ConcurrentVec<T>` is just a wrapper around `ConcurrentBag<Option<T>>` with additional guarantees to enable safe concurrent reading.
-    ///
-    /// Therefore, without a cost
-    /// * `ConcurrentVec<T>` can be constructed from any `ConcurrentBag<Option<T>>` by calling `bag.into()`, and
-    /// * the underlying `ConcurrentBag<Option<T>>` can be obtained from `ConcurrentVec<T>` by calling `con_vec.into()` method.
-    fn from(bag: ConcurrentBag<Option<T>, P>) -> Self {
-        let pinned = bag.into_inner();
-        Self::from_pinned_vec(pinned)
-    }
-}
-
-impl<T, P> From<ConcurrentVec<T, P>> for ConcurrentBag<Option<T>, P>
-where
-    P: PinnedVec<Option<T>>,
-{
-    /// `ConcurrentVec<T>` is just a wrapper around `ConcurrentBag<Option<T>>` with additional guarantees to enable safe concurrent reading.
-    ///
-    /// Therefore, without a cost
-    /// * `ConcurrentVec<T>` can be constructed from any `ConcurrentBag<Option<T>>` by calling `bag.into()`, and
-    /// * the underlying `ConcurrentBag<Option<T>>` can be obtained from `ConcurrentVec<T>` by calling `con_vec.into()` method.
-    fn from(con_vec: ConcurrentVec<T, P>) -> Self {
-        let pinned = con_vec.bag.into_inner();
-        ConcurrentBag::from(pinned)
-    }
-}
-
-// impl
 impl<T, P> ConcurrentVec<T, P>
 where
     P: PinnedVec<Option<T>>,
 {
     /// Consumes the concurrent bag and returns the underlying pinned vector.
     ///
-    /// Any `PinnedVec<Option<T>>` implementation can be converted to a `ConcurrentVec<T>` using the `From` trait.
+    /// Any `PinnedVec` implementation can be converted to a `ConcurrentBag` using the `From` trait.
     /// Similarly, underlying pinned vector can be obtained by calling the consuming `into_inner` method.
     ///
     /// # Examples
     ///
     /// ```rust
-    /// use orx_concurrent_vec::*;
+    /// use orx_concurrent_bag::*;
     ///
-    /// let con_vec = ConcurrentVec::new();
+    /// let bag = ConcurrentBag::new();
     ///
-    /// con_vec.push('a');
-    /// con_vec.push('b');
-    /// con_vec.push('c');
-    /// con_vec.push('d');
-    /// assert_eq!(vec!['a', 'b', 'c', 'd'], con_vec.iter().copied().collect::<Vec<_>>());
+    /// bag.push('a');
+    /// bag.push('b');
+    /// bag.push('c');
+    /// bag.push('d');
+    /// assert_eq!(vec!['a', 'b', 'c', 'd'], unsafe { bag.iter() }.copied().collect::<Vec<_>>());
     ///
-    /// let mut split = con_vec.into_inner();
-    /// assert_eq!(vec!['a', 'b', 'c', 'd'], split.iter().copied().flatten().collect::<Vec<_>>());
+    /// let mut split = bag.into_inner();
+    /// assert_eq!(vec!['a', 'b', 'c', 'd'], split.iter().copied().collect::<Vec<_>>());
     ///
-    /// split.push(Some('e'));
-    /// *split.get_mut(0).expect("exists") = Some('x');
+    /// split.push('e');
+    /// *split.get_mut(0).expect("exists") = 'x';
     ///
-    /// assert_eq!(vec!['x', 'b', 'c', 'd', 'e'], split.iter().copied().flatten().collect::<Vec<_>>());
+    /// assert_eq!(vec!['x', 'b', 'c', 'd', 'e'], split.iter().copied().collect::<Vec<_>>());
     ///
-    /// let mut con_vec: ConcurrentVec<_> = split.into();
-    /// assert_eq!(vec!['x', 'b', 'c', 'd', 'e'], con_vec.iter().copied().collect::<Vec<_>>());
+    /// let mut bag: ConcurrentBag<_> = split.into();
+    /// assert_eq!(vec!['x', 'b', 'c', 'd', 'e'], unsafe { bag.iter() }.copied().collect::<Vec<_>>());
     ///
-    /// con_vec.clear();
-    /// assert!(con_vec.is_empty());
+    /// bag.clear();
+    /// assert!(bag.is_empty());
     ///
-    /// let split = con_vec.into_inner();
+    /// let split = bag.into_inner();
     /// assert!(split.is_empty());
     pub fn into_inner(self) -> P {
         self.bag.into_inner()
-    }
-
-    /// ***O(1)*** Returns the number of elements which are pushed to the vec, including the elements which received their reserved locations and are currently being pushed.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use orx_concurrent_vec::ConcurrentVec;
-    ///
-    /// let con_vec = ConcurrentVec::new();
-    /// con_vec.push('a');
-    /// con_vec.push('b');
-    ///
-    /// assert_eq!(2, con_vec.len());
-    /// ```
-    #[inline(always)]
-    pub fn len(&self) -> usize {
-        self.bag.len()
     }
 
     /// ***O(n)*** Returns the number of elements which are completely pushed to the vector, excluding elements which received their reserved locations and currently being pushed.
@@ -314,197 +222,6 @@ where
     #[inline(always)]
     pub fn len_exact(&self) -> usize {
         self.iter().count()
-    }
-
-    /// ***O(1)*** Returns the current capacity of the concurrent vec; i.e., the underlying pinned vector storage.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use orx_concurrent_vec::ConcurrentVec;
-    ///
-    /// let con_vec = ConcurrentVec::new();
-    /// con_vec.push('a');
-    /// con_vec.push('b');
-    ///
-    /// assert_eq!(4, con_vec.capacity());
-    ///
-    /// con_vec.push('c');
-    /// con_vec.push('d');
-    /// con_vec.push('e');
-    ///
-    /// assert_eq!(12, con_vec.capacity());
-    /// ```
-    #[inline(always)]
-    pub fn capacity(&self) -> usize {
-        self.bag.capacity()
-    }
-
-    /// Note that a `ConcurrentVec` contains two capacity methods:
-    /// * `capacity`: returns current capacity of the underlying pinned vector; this capacity can grow concurrently with a `&self` reference; i.e., during a `push` call
-    /// * `maximum_capacity`: returns the maximum potential capacity that the pinned vector can grow up to with a `&self` reference;
-    ///   * `push`ing a new element while the bag is at `maximum_capacity` leads to panic.
-    ///
-    /// On the other hand, maximum capacity can safely be increased by a mutually exclusive `&mut self` reference using the `reserve_maximum_capacity`.
-    /// However, underlying pinned vector must be able to provide pinned-element guarantees during this operation.
-    ///
-    /// Among the common pinned vector implementations:
-    /// * `SplitVec<_, Doubling>`: supports this method; however, it does not require for any practical size.
-    /// * `SplitVec<_, Linear>`: is guaranteed to succeed and increase its maximum capacity to the required value.
-    /// * `FixedVec<_>`: is the most strict pinned vector which cannot grow even in a single-threaded setting. Currently, it will always return an error to this call.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use orx_concurrent_vec::*;
-    /// use orx_pinned_vec::PinnedVecGrowthError;
-    ///
-    ///  // SplitVec<_, Doubling> (default)
-    /// let con_vec: ConcurrentVec<char> = ConcurrentVec::new();
-    /// assert_eq!(con_vec.capacity(), 4); // only allocates the first fragment of 4
-    /// assert_eq!(con_vec.maximum_capacity(), 17_179_869_180); // it can grow safely & exponentially
-    ///
-    /// let con_vec: ConcurrentVec<char, _> = ConcurrentVec::with_doubling_growth();
-    /// assert_eq!(con_vec.capacity(), 4);
-    /// assert_eq!(con_vec.maximum_capacity(), 17_179_869_180);
-    ///
-    /// // SplitVec<_, Linear>
-    /// let mut con_vec: ConcurrentVec<char, _> = ConcurrentVec::with_linear_growth(10, 20);
-    /// assert_eq!(con_vec.capacity(), 2usize.pow(10)); // only allocates first fragment of 1024
-    /// assert_eq!(con_vec.maximum_capacity(), 2usize.pow(10) * 20); // it can concurrently allocate 19 more
-    ///
-    /// // SplitVec<_, Linear> -> reserve_maximum_capacity
-    /// let result = con_vec.reserve_maximum_capacity(2usize.pow(10) * 30);
-    /// assert_eq!(result, Ok(2usize.pow(10) * 30));
-    ///
-    /// // actually no new allocation yet; precisely additional memory for 10 pairs of pointers is used
-    /// assert_eq!(con_vec.capacity(), 2usize.pow(10)); // still only the first fragment capacity
-    ///
-    /// dbg!(con_vec.maximum_capacity(), 2usize.pow(10) * 30);
-    /// assert_eq!(con_vec.maximum_capacity(), 2usize.pow(10) * 30); // now it can safely reach 2^10 * 30
-    ///
-    /// // FixedVec<_>: pre-allocated, exact and strict
-    /// let mut con_vec: ConcurrentVec<char, _> = ConcurrentVec::with_fixed_capacity(42);
-    /// assert_eq!(con_vec.capacity(), 42);
-    /// assert_eq!(con_vec.maximum_capacity(), 42);
-    ///
-    /// let result = con_vec.reserve_maximum_capacity(43);
-    /// assert_eq!(
-    ///     result,
-    ///     Err(PinnedVecGrowthError::FailedToGrowWhileKeepingElementsPinned)
-    /// );
-    /// ```
-    pub fn reserve_maximum_capacity(
-        &mut self,
-        maximum_capacity: usize,
-    ) -> Result<usize, PinnedVecGrowthError> {
-        self.bag.reserve_maximum_capacity(maximum_capacity)
-    }
-
-    /// Returns the maximum possible capacity that the concurrent vector can reach.
-    /// This is equivalent to the maximum capacity that the underlying pinned vector can safely reach in a concurrent program.
-    ///
-    /// Note that `maximum_capacity` differs from `capacity` due to the following:
-    /// * `capacity` represents currently allocated memory owned by the underlying pinned vector.
-    /// The vector can possibly grow beyond this value.
-    /// * `maximum_capacity` represents the hard upper limit on the length of the concurrent vector.
-    /// Attempting to grow the vector beyond this value leads to an error.
-    /// Note that this is not necessarily a limitation for the underlying split vector; the limitation might be due to the additional safety requirements of concurrent programs.
-    ///
-    /// # Safety
-    ///
-    /// Calling `push` while the vector is at its `maximum_capacity` leads to a panic.    
-    /// This condition is a safety requirement.
-    /// Underlying pinned vector cannot safely grow beyond maximum capacity in a possibly concurrent call (with `&self`).
-    /// This would lead to UB.
-    ///
-    /// It is easy to overcome this problem during construction:
-    /// * It is not observed with the default pinned vector `SplitVec<_, Doubling>`:
-    ///   * `ConcurrentBag::new()`
-    ///   * `ConcurrentBag::with_doubling_growth()`
-    /// * It can be avoided cheaply when `SplitVec<_, Linear>` is used by setting the second argument to a proper value:
-    ///   * `ConcurrentBag::with_linear_growth(10, 32)`
-    ///     * Each fragment of this vector will have a capacity of 2^10 = 1024.
-    ///     * It can safely grow up to 32 fragments with `&self` reference.
-    ///     * Therefore, it is safe to concurrently grow this vector to 32 * 1024 elements.
-    ///     * Cost of replacing 32 with 64 is negligible in such a scenario (the difference in memory allocation is precisely 32 * 2*usize).
-    /// * Using the variant `FixedVec<_>` requires a hard bound and pre-allocation regardless the program is concurrent or not.
-    ///   * `ConcurrentBag::with_fixed_capacity(1024)`
-    ///     * Unlike the split vector variants, this variant pre-allocates for 1024 elements.
-    ///     * And can never grow beyond this value.
-    ///
-    /// Alternatively, caller can try to safely reserve the required capacity any time by a mutually exclusive reference:
-    /// * `ConcurrentBag.reserve_maximum_capacity(&mut self, maximum_capacity: usize)`
-    ///   * this call will always succeed with `SplitVec<_, Doubling>` and `SplitVec<_, Linear>`,
-    ///   * will always fail for `FixedVec<_>`.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use orx_concurrent_vec::*;
-    /// use orx_pinned_vec::PinnedVecGrowthError;
-    ///
-    ///  // SplitVec<_, Doubling> (default)
-    /// let con_vec: ConcurrentVec<char> = ConcurrentVec::new();
-    /// assert_eq!(con_vec.capacity(), 4); // only allocates the first fragment of 4
-    /// assert_eq!(con_vec.maximum_capacity(), 17_179_869_180); // it can grow safely & exponentially
-    ///
-    /// let con_vec: ConcurrentVec<char, _> = ConcurrentVec::with_doubling_growth();
-    /// assert_eq!(con_vec.capacity(), 4);
-    /// assert_eq!(con_vec.maximum_capacity(), 17_179_869_180);
-    ///
-    /// // SplitVec<_, Linear>
-    /// let mut con_vec: ConcurrentVec<char, _> = ConcurrentVec::with_linear_growth(10, 20);
-    /// assert_eq!(con_vec.capacity(), 2usize.pow(10)); // only allocates first fragment of 1024
-    /// assert_eq!(con_vec.maximum_capacity(), 2usize.pow(10) * 20); // it can concurrently allocate 19 more
-    ///
-    /// // SplitVec<_, Linear> -> reserve_maximum_capacity
-    /// let result = con_vec.reserve_maximum_capacity(2usize.pow(10) * 30);
-    /// assert_eq!(result, Ok(2usize.pow(10) * 30));
-    ///
-    /// // actually no new allocation yet; precisely additional memory for 10 pairs of pointers is used
-    /// assert_eq!(con_vec.capacity(), 2usize.pow(10)); // still only the first fragment capacity
-    ///
-    /// dbg!(con_vec.maximum_capacity(), 2usize.pow(10) * 30);
-    /// assert_eq!(con_vec.maximum_capacity(), 2usize.pow(10) * 30); // now it can safely reach 2^10 * 30
-    ///
-    /// // FixedVec<_>: pre-allocated, exact and strict
-    /// let mut con_vec: ConcurrentVec<char, _> = ConcurrentVec::with_fixed_capacity(42);
-    /// assert_eq!(con_vec.capacity(), 42);
-    /// assert_eq!(con_vec.maximum_capacity(), 42);
-    ///
-    /// let result = con_vec.reserve_maximum_capacity(43);
-    /// assert_eq!(
-    ///     result,
-    ///     Err(PinnedVecGrowthError::FailedToGrowWhileKeepingElementsPinned)
-    /// );
-    /// ```
-    #[inline]
-    pub fn maximum_capacity(&self) -> usize {
-        self.bag.maximum_capacity()
-    }
-
-    /// ***O(1)*** Returns whether the con_vec is empty (`len() == 0`) or not.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use orx_concurrent_vec::ConcurrentVec;
-    ///
-    /// let mut con_vec = ConcurrentVec::new();
-    ///
-    /// assert!(con_vec.is_empty());
-    ///
-    /// con_vec.push('a');
-    /// con_vec.push('b');
-    /// assert!(!con_vec.is_empty());
-    ///
-    /// con_vec.clear();
-    /// assert!(con_vec.is_empty());
-    /// ```
-    #[inline(always)]
-    pub fn is_empty(&self) -> bool {
-        self.bag.is_empty()
     }
 
     /// Returns an iterator to elements of the vector.
@@ -557,7 +274,6 @@ where
         unsafe { self.bag.get(index) }.and_then(|x| x.as_ref())
     }
 
-    // mutate collection
     /// Concurrent, thread-safe method to push the given `value` to the back of the concurrent vector,
     /// and returns the position or index of the pushed value.
     ///
@@ -568,7 +284,7 @@ where
     /// Panics if the concurrent vector is already at its maximum capacity; i.e., if `self.len() == self.maximum_capacity()`.
     ///
     /// Note that this is an important safety assertion in the concurrent context; however, not a practical limitation.
-    /// Please see the [`ConcurrentVec::maximum_capacity`] for details.
+    /// Please see the [`orx_pinned_concurrent_col::PinnedConcurrentCol::maximum_capacity`] for details.
     ///
     /// # Examples
     ///
@@ -604,15 +320,16 @@ where
     ///
     /// # Performance Notes - False Sharing
     ///
-    /// [`ConcurrentVec::push`] method is implementation is simple, lock-free and efficient.
+    /// [`ConcurrentVec::push`] implementation is lock-free and focuses on efficiency.
     /// However, we need to be aware of the potential [false sharing](https://en.wikipedia.org/wiki/False_sharing) risk.
-    /// False sharing might lead to significant performance degradation; fortunately, it is possible to avoid in many cases.
+    /// False sharing might lead to significant performance degradation.
+    /// However, it is possible to avoid in many cases.
     ///
     /// ## When?
     ///
     /// Performance degradation due to false sharing might be observed when both of the following conditions hold:
     /// * **small data**: data to be pushed is small, the more elements fitting in a cache line the bigger the risk,
-    /// * **little work**: multiple threads/cores are pushing to the concurrent vector with high frequency; i.e.,
+    /// * **little work**: multiple threads/cores are pushing to the concurrent bag with high frequency; i.e.,
     ///   * very little or negligible work / time is required in between `push` calls.
     ///
     /// The example above fits this situation.
@@ -623,7 +340,7 @@ where
     /// * `ConcurrentVec` assigns unique positions to each value to be pushed. There is no *true* sharing among threads in the position level.
     /// * However, cache lines contain more than one position.
     /// * One thread updating a particular position invalidates the entire cache line on an other thread.
-    /// * Threads end up frequently reloading cache lines instead of doing the actual work of writing elements to the vector.
+    /// * Threads end up frequently reloading cache lines instead of doing the actual work of writing elements to the bag.
     /// * This might lead to a significant performance degradation.
     ///
     /// Following two methods could be approached to deal with this problem.
@@ -656,10 +373,10 @@ where
     ///
     /// let (num_threads, num_items_per_thread) = (4, 1_024);
     ///
-    /// let con_vec = ConcurrentVec::new();
+    /// let bag = ConcurrentVec::new();
     ///
     /// // just take a reference and share among threads
-    /// let vec_ref = &con_vec;
+    /// let bag_ref = &bag;
     /// let batch_size = 16;
     ///
     /// std::thread::scope(|s| {
@@ -668,24 +385,23 @@ where
     ///             for j in (0..num_items_per_thread).step_by(batch_size) {
     ///                 let iter = (j..(j + batch_size)).map(|j| i * 1000 + j);
     ///                 // concurrently collect results simply by calling `extend`
-    ///                 vec_ref.extend(iter);
+    ///                 bag_ref.extend(iter);
     ///             }
     ///         });
     ///     }
     /// });
     ///
-    /// let mut results: Vec<_> = con_vec.into_inner().iter().flatten().copied().collect();
-    /// results.sort();
+    /// let mut vec_from_bag: Vec<_> = bag.into_inner().iter().flatten().copied().collect();
+    /// vec_from_bag.sort();
     /// let mut expected: Vec<_> = (0..num_threads).flat_map(|i| (0..num_items_per_thread).map(move |j| i * 1000 + j)).collect();
     /// expected.sort();
-    /// assert_eq!(results, expected);
+    /// assert_eq!(vec_from_bag, expected);
     /// ```
     ///
     /// ## Solution-II: Padding
     ///
-    /// Another common approach to deal with false sharing is to add padding (unused bytes) between elements.
+    /// Another approach to deal with false sharing is to add padding (unused bytes) between elements.
     /// There exist wrappers which automatically adds cache padding, such as crossbeam's [`CachePadded`](https://docs.rs/crossbeam-utils/latest/crossbeam_utils/struct.CachePadded.html).
-    /// In other words, instead of using a `ConcurrentBag<T>`, we can use `ConcurrentBag<CachePadded<T>>`.
     /// However, this solution leads to increased memory requirement.
     #[inline(always)]
     pub fn push(&self, value: T) -> usize {
@@ -702,20 +418,22 @@ where
     /// * and the last value will be written to the `begin_idx + values.count() - 1`-th position of the vector.
     ///
     /// Important notes:
-    /// * This method does not allocate at all to buffer elements to be pushed.
+    /// * This method does not allocate to buffer.
     /// * All it does is to increment the atomic counter by the length of the iterator (`push` would increment by 1) and reserve the range of positions for this operation.
-    /// * Iterating over and writing elements to the vector happens afterwards.
-    /// * This is a simple, effective and memory efficient solution to the false sharing problem which could be observed in *small data & little work* situations.
+    /// * If there is not sufficient space, the vector grows first; iterating over and writing elements to the vector happens afterwards.
+    /// * Therefore, other threads do not wait for the `extend` method to complete, they can concurrently write.
+    /// * This is a simple and effective approach to deal with the false sharing problem which could be observed in *small data & little work* situations.
     ///
     /// For this reason, the method requires an `ExactSizeIterator`.
-    /// There exists the variant [`ConcurrentVec::extend_n_items`] method which accepts any iterator together with the correct length to be passed by the caller, hence it is `unsafe`.
+    /// There exists the variant [`ConcurrentBag::extend_n_items`] method which accepts any iterator together with the correct length to be passed by the caller.
+    /// It is `unsafe` as the caller must guarantee that the iterator yields at least the number of elements explicitly passed in as an argument.
     ///
     /// # Panics
     ///
     /// Panics if not all of the `values` fit in the concurrent vector's maximum capacity.
     ///
     /// Note that this is an important safety assertion in the concurrent context; however, not a practical limitation.
-    /// Please see the [`ConcurrentVec::maximum_capacity`] for details.
+    /// Please see the [`PinnedConcurrentCol::maximum_capacity`] for details.
     ///
     /// # Examples
     ///
@@ -726,10 +444,10 @@ where
     ///
     /// let (num_threads, num_items_per_thread) = (4, 1_024);
     ///
-    /// let vector = ConcurrentVec::new();
+    /// let bag = ConcurrentVec::new();
     ///
     /// // just take a reference and share among threads
-    /// let vec_ref = &vector;
+    /// let bag_ref = &bag;
     /// let batch_size = 16;
     ///
     /// std::thread::scope(|s| {
@@ -738,17 +456,17 @@ where
     ///             for j in (0..num_items_per_thread).step_by(batch_size) {
     ///                 let iter = (j..(j + batch_size)).map(|j| i * 1000 + j);
     ///                 // concurrently collect results simply by calling `extend`
-    ///                 vec_ref.extend(iter);
+    ///                 bag_ref.extend(iter);
     ///             }
     ///         });
     ///     }
     /// });
     ///
-    /// let mut results: Vec<_> = vector.into_inner().iter().flatten().copied().collect();
-    /// results.sort();
+    /// let mut vec_from_bag: Vec<_> = bag.into_inner().iter().flatten().copied().collect();
+    /// vec_from_bag.sort();
     /// let mut expected: Vec<_> = (0..num_threads).flat_map(|i| (0..num_items_per_thread).map(move |j| i * 1000 + j)).collect();
     /// expected.sort();
-    /// assert_eq!(results, expected);
+    /// assert_eq!(vec_from_bag, expected);
     /// ```
     ///
     /// # Performance Notes - False Sharing
@@ -761,7 +479,7 @@ where
     ///
     /// Performance degradation due to false sharing might be observed when both of the following conditions hold:
     /// * **small data**: data to be pushed is small, the more elements fitting in a cache line the bigger the risk,
-    /// * **little work**: multiple threads/cores are pushing to the concurrent vector with high frequency; i.e.,
+    /// * **little work**: multiple threads/cores are pushing to the concurrent bag with high frequency; i.e.,
     ///   * very little or negligible work / time is required in between `push` calls.
     ///
     /// The example above fits this situation.
@@ -772,7 +490,7 @@ where
     /// * `ConcurrentVec` assigns unique positions to each value to be pushed. There is no *true* sharing among threads in the position level.
     /// * However, cache lines contain more than one position.
     /// * One thread updating a particular position invalidates the entire cache line on an other thread.
-    /// * Threads end up frequently reloading cache lines instead of doing the actual work of writing elements to the vector.
+    /// * Threads end up frequently reloading cache lines instead of doing the actual work of writing elements to the bag.
     /// * This might lead to a significant performance degradation.
     ///
     /// Following two methods could be approached to deal with this problem.
@@ -793,7 +511,7 @@ where
     /// Performance gains after reaching the cache line size are much lesser.
     ///
     /// For instance, consider the challenging super small element size case, where we are collecting `i32`s.
-    /// We can already achieve a very high performance by simply `extend`ing the vector by batches of 16 elements.
+    /// We can already achieve a very high performance by simply `extend`ing the bag by batches of 16 elements.
     ///
     /// As the element size gets larger, required batch size to achieve a high performance gets smaller and smaller.
     ///
@@ -803,7 +521,6 @@ where
     ///
     /// Another common approach to deal with false sharing is to add padding (unused bytes) between elements.
     /// There exist wrappers which automatically adds cache padding, such as crossbeam's [`CachePadded`](https://docs.rs/crossbeam-utils/latest/crossbeam_utils/struct.CachePadded.html).
-    /// In other words, instead of using a `ConcurrentVec<T>`, we can use `ConcurrentVec<CachePadded<T>>`.
     /// However, this solution leads to increased memory requirement.
     #[inline(always)]
     pub fn extend<IntoIter, Iter>(&self, values: IntoIter) -> usize
@@ -838,7 +555,7 @@ where
     /// Panics if `num_items` elements do not fit in the concurrent vector's maximum capacity.
     ///
     /// Note that this is an important safety assertion in the concurrent context; however, not a practical limitation.
-    /// Please see the [`ConcurrentVec::maximum_capacity`] for details.
+    /// Please see the [`PinnedConcurrentCol::maximum_capacity`] for details.
     ///
     /// # Safety
     ///
@@ -866,10 +583,10 @@ where
     ///
     /// let (num_threads, num_items_per_thread) = (4, 1_024);
     ///
-    /// let vector = ConcurrentVec::new();
+    /// let bag = ConcurrentVec::new();
     ///
     /// // just take a reference and share among threads
-    /// let vec_ref = &vector;
+    /// let bag_ref = &bag;
     /// let batch_size = 16;
     ///
     /// std::thread::scope(|s| {
@@ -878,17 +595,17 @@ where
     ///             for j in (0..num_items_per_thread).step_by(batch_size) {
     ///                 let iter = (j..(j + batch_size)).map(|j| i * 1000 + j);
     ///                 // concurrently collect results simply by calling `extend_n_items`
-    ///                 unsafe { vec_ref.extend_n_items(iter, batch_size) };
+    ///                 unsafe { bag_ref.extend_n_items(iter, batch_size) };
     ///             }
     ///         });
     ///     }
     /// });
     ///
-    /// let mut results: Vec<_> = vector.into_inner().iter().flatten().copied().collect();
-    /// results.sort();
+    /// let mut vec_from_bag: Vec<_> = bag.into_inner().iter().flatten().copied().collect();
+    /// vec_from_bag.sort();
     /// let mut expected: Vec<_> = (0..num_threads).flat_map(|i| (0..num_items_per_thread).map(move |j| i * 1000 + j)).collect();
     /// expected.sort();
-    /// assert_eq!(results, expected);
+    /// assert_eq!(vec_from_bag, expected);
     /// ```
     ///
     /// # Performance Notes - False Sharing
@@ -901,7 +618,7 @@ where
     ///
     /// Performance degradation due to false sharing might be observed when both of the following conditions hold:
     /// * **small data**: data to be pushed is small, the more elements fitting in a cache line the bigger the risk,
-    /// * **little work**: multiple threads/cores are pushing to the concurrent vector with high frequency; i.e.,
+    /// * **little work**: multiple threads/cores are pushing to the concurrent bag with high frequency; i.e.,
     ///   * very little or negligible work / time is required in between `push` calls.
     ///
     /// The example above fits this situation.
@@ -912,7 +629,7 @@ where
     /// * `ConcurrentVec` assigns unique positions to each value to be pushed. There is no *true* sharing among threads in the position level.
     /// * However, cache lines contain more than one position.
     /// * One thread updating a particular position invalidates the entire cache line on an other thread.
-    /// * Threads end up frequently reloading cache lines instead of doing the actual work of writing elements to the vector.
+    /// * Threads end up frequently reloading cache lines instead of doing the actual work of writing elements to the bag.
     /// * This might lead to a significant performance degradation.
     ///
     /// Following two methods could be approached to deal with this problem.
@@ -933,7 +650,7 @@ where
     /// Performance gains after reaching the cache line size are much lesser.
     ///
     /// For instance, consider the challenging super small element size case, where we are collecting `i32`s.
-    /// We can already achieve a very high performance by simply `extend`ing the vector by batches of 16 elements.
+    /// We can already achieve a very high performance by simply `extend`ing the bag by batches of 16 elements.
     ///
     /// As the element size gets larger, required batch size to achieve a high performance gets smaller and smaller.
     ///
@@ -943,7 +660,6 @@ where
     ///
     /// Another common approach to deal with false sharing is to add padding (unused bytes) between elements.
     /// There exist wrappers which automatically adds cache padding, such as crossbeam's [`CachePadded`](https://docs.rs/crossbeam-utils/latest/crossbeam_utils/struct.CachePadded.html).
-    /// In other words, instead of using a `ConcurrentVec<T>`, we can use `ConcurrentVec<CachePadded<T>>`.
     /// However, this solution leads to increased memory requirement.
     #[inline(always)]
     pub unsafe fn extend_n_items<IntoIter>(&self, values: IntoIter, num_items: usize) -> usize
@@ -953,514 +669,43 @@ where
         let values = values.into_iter().map(Some);
         self.bag.extend_n_items::<_>(values, num_items)
     }
+}
 
-    /// Clears the concurrent vector removing all already pushed elements.
-    ///
-    /// # Safety
-    ///
-    /// This method requires a mutually exclusive reference.
-    /// This guarantees that there might not be any continuing writing process of a `push` operation.
-    /// Therefore, the elements can safely be cleared.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use orx_concurrent_vec::ConcurrentVec;
-    ///
-    /// let mut vector = ConcurrentVec::new();
-    ///
-    /// vector.push('a');
-    /// vector.push('b');
-    ///
-    /// vector.clear();
-    /// assert!(vector.is_empty());
-    /// ```
-    pub fn clear(&mut self) {
-        self.bag.clear()
-    }
+// HELPERS
 
-    // helpers
-    fn from_pinned_vec(pinned: P) -> Self {
-        let bag = ConcurrentBag::new_with_mem_zeroing(pinned);
+impl<T, P> ConcurrentVec<T, P>
+where
+    P: PinnedVec<Option<T>>,
+{
+    #[inline]
+    pub(crate) fn new_from_pinned(pinned_vec: P) -> Self {
+        let bag: ConcurrentBag<_, _> = pinned_vec.into();
         Self { bag }
+    }
+}
+
+// TRAITS
+
+impl<T, P> Deref for ConcurrentVec<T, P>
+where
+    P: PinnedVec<Option<T>>,
+{
+    type Target = ConcurrentBag<Option<T>, P>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.bag
+    }
+}
+
+impl<T, P> DerefMut for ConcurrentVec<T, P>
+where
+    P: PinnedVec<Option<T>>,
+{
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.bag
     }
 }
 
 unsafe impl<T: Sync, P: PinnedVec<Option<T>>> Sync for ConcurrentVec<T, P> {}
 
 unsafe impl<T: Send, P: PinnedVec<Option<T>>> Send for ConcurrentVec<T, P> {}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use orx_split_vec::Recursive;
-    use std::{
-        collections::HashSet,
-        sync::{Arc, Mutex},
-        time::Duration,
-    };
-
-    #[test]
-    fn write_read() {
-        #[derive(Default, Debug)]
-        struct Metric {
-            sum: i32,
-            count: i32,
-        }
-        impl Metric {
-            fn aggregate(self, value: &i32) -> Self {
-                Self {
-                    sum: self.sum + value,
-                    count: self.count + 1,
-                }
-            }
-        }
-
-        // record measurements in random intervals (read & write -> ConcurrentVec)
-        let measurements = ConcurrentVec::new();
-        let rf_measurements = &measurements;
-
-        // collect metrics every 50 milliseconds (only write -> ConcurrentBag)
-        let metrics = ConcurrentBag::new();
-        let rf_metrics = &metrics;
-
-        std::thread::scope(|s| {
-            // thread to store measurements
-            s.spawn(move || {
-                for i in 0..100 {
-                    std::thread::sleep(Duration::from_millis(i % 5));
-
-                    // collect results and push to measurements vec
-                    rf_measurements.push(i as i32);
-                }
-            });
-
-            // thread to collect metrics every 50 milliseconds
-            s.spawn(move || {
-                for _ in 0..10 {
-                    // safely read from measurements vec
-                    let metric = rf_measurements
-                        .iter()
-                        .fold(Metric::default(), |x, value| x.aggregate(value));
-
-                    // push results to metrics bag
-                    // we may also use `ConcurrentVec` but we prefer `ConcurrentBag`
-                    // since we don't concurrently read metrics
-                    rf_metrics.push(metric);
-
-                    std::thread::sleep(Duration::from_millis(50));
-                }
-            });
-
-            // thread to print out the values to the stdout every 100 milliseconds
-            s.spawn(move || {
-                let mut idx = 0;
-                loop {
-                    let current_len = rf_measurements.len_exact();
-                    let begin = idx;
-
-                    for i in begin..current_len {
-                        // safely read from measurements vec
-                        if let Some(value) = rf_measurements.get(i) {
-                            println!("[{}] = {:?}", i, value);
-                            idx += 1;
-                        } else {
-                            idx = i;
-                            break;
-                        }
-                    }
-
-                    if current_len == 100 {
-                        break;
-                    }
-
-                    std::thread::sleep(Duration::from_millis(100));
-                }
-            });
-        });
-
-        assert_eq!(measurements.len(), 100);
-        assert_eq!(metrics.len(), 10);
-    }
-
-    #[test]
-    fn new_len_empty_clear() {
-        fn test<P: PinnedVec<Option<char>>>(bag: ConcurrentVec<char, P>) {
-            let mut bag = bag;
-
-            assert!(bag.is_empty());
-            assert_eq!(0, bag.len());
-
-            bag.push('a');
-
-            assert!(!bag.is_empty());
-            assert_eq!(1, bag.len());
-
-            bag.push('b');
-            bag.push('c');
-            bag.push('d');
-
-            assert!(!bag.is_empty());
-            assert_eq!(4, bag.len());
-
-            bag.clear();
-            assert!(bag.is_empty());
-            assert_eq!(0, bag.len());
-        }
-
-        test(ConcurrentVec::new());
-        test(ConcurrentVec::default());
-        test(ConcurrentVec::with_doubling_growth());
-        test(ConcurrentVec::with_linear_growth(2, 8));
-        test(ConcurrentVec::with_linear_growth(4, 8));
-        test(ConcurrentVec::with_fixed_capacity(64));
-    }
-
-    #[test]
-    fn capacity() {
-        let mut split: SplitVec<_, Doubling> = (0..4).map(Some).collect();
-        split.concurrent_reserve(5);
-        let bag: ConcurrentVec<_, _> = split.into();
-        assert_eq!(bag.capacity(), 4);
-        bag.push(42);
-        assert_eq!(bag.capacity(), 12);
-
-        let mut split: SplitVec<_, Recursive> = (0..4).map(Some).collect();
-        split.concurrent_reserve(5);
-        let bag: ConcurrentVec<_, _> = split.into();
-        assert_eq!(bag.capacity(), 4);
-        bag.push(42);
-        assert_eq!(bag.capacity(), 12);
-
-        let mut split: SplitVec<_, Linear> = SplitVec::with_linear_growth(2);
-        split.extend_from_slice(&[0, 1, 2, 3].map(Some));
-        split.concurrent_reserve(5);
-        let bag: ConcurrentVec<_, _> = split.into();
-        assert_eq!(bag.capacity(), 4);
-        bag.push(42);
-        assert_eq!(bag.capacity(), 8);
-
-        let mut fixed: FixedVec<_> = FixedVec::new(5);
-        fixed.extend_from_slice(&[0, 1, 2, 3].map(Some));
-        let bag: ConcurrentVec<_, _> = fixed.into();
-        assert_eq!(bag.capacity(), 5);
-        bag.push(42);
-        assert_eq!(bag.capacity(), 5);
-    }
-
-    #[test]
-    #[should_panic]
-    fn exceeding_fixed_capacity_panics() {
-        let mut fixed: FixedVec<_> = FixedVec::new(5);
-        fixed.extend_from_slice(&[0, 1, 2, 3].map(Some));
-        let bag: ConcurrentVec<_, _> = fixed.into();
-        assert_eq!(bag.capacity(), 5);
-        bag.push(42);
-        bag.push(7);
-    }
-
-    #[test]
-    #[should_panic]
-    fn exceeding_fixed_capacity_panics_concurrently() {
-        let bag = ConcurrentVec::with_fixed_capacity(10);
-        let bag_ref = &bag;
-        std::thread::scope(|s| {
-            for _ in 0..4 {
-                s.spawn(move || {
-                    for _ in 0..3 {
-                        // in total there will be 4*3 = 12 pushes
-                        bag_ref.push(42);
-                    }
-                });
-            }
-        });
-    }
-
-    #[test]
-    fn debug() {
-        let bag = ConcurrentVec::new();
-
-        bag.push('a');
-        bag.push('b');
-        bag.push('c');
-        bag.push('d');
-        bag.push('e');
-
-        let str = format!("{:?}", bag);
-        assert_eq!(
-            str,
-            "ConcurrentVec { bag: ConcurrentBag { pinned: [Some('a'), Some('b'), Some('c'), Some('d'), Some('e')], len: 5, capacity: 12, maximum_capacity: 17179869180 } }"
-        );
-    }
-
-    #[test]
-    fn get() {
-        // record measurements in (assume) random intervals
-        let measurements = ConcurrentVec::<i32>::new();
-        let rf_measurements = &measurements;
-
-        // collect sum of measurements every 50 milliseconds
-        let sums = ConcurrentVec::new();
-        let rf_sums = &sums;
-
-        // collect average of measurements every 50 milliseconds
-        let averages = ConcurrentVec::new();
-        let rf_averages = &averages;
-
-        std::thread::scope(|s| {
-            s.spawn(move || {
-                for i in 0..100 {
-                    std::thread::sleep(Duration::from_millis(i % 5));
-                    rf_measurements.push(i as i32);
-                }
-            });
-
-            s.spawn(move || {
-                for _ in 0..10 {
-                    let mut sum = 0;
-                    for i in 0..rf_measurements.len() {
-                        sum += rf_measurements.get(i).copied().unwrap_or(0);
-                    }
-                    rf_sums.push(sum);
-                    std::thread::sleep(Duration::from_millis(50));
-                }
-            });
-
-            s.spawn(move || {
-                for _ in 0..10 {
-                    let count = rf_measurements.len();
-                    if count == 0 {
-                        rf_averages.push(0.0);
-                    } else {
-                        let mut sum = 0;
-                        for i in 0..rf_measurements.len() {
-                            sum += rf_measurements.get(i).copied().unwrap_or(0);
-                        }
-                        let average = sum as f32 / count as f32;
-                        rf_averages.push(average);
-                    }
-                    std::thread::sleep(Duration::from_millis(50));
-                }
-            });
-        });
-
-        assert_eq!(measurements.len(), 100);
-        assert_eq!(sums.len(), 10);
-        assert_eq!(averages.len(), 10);
-    }
-
-    #[test]
-    fn iter() {
-        let mut bag = ConcurrentVec::new();
-
-        assert_eq!(0, bag.iter().count());
-
-        bag.push('a');
-
-        assert_eq!(vec!['a'], bag.iter().copied().collect::<Vec<_>>());
-
-        bag.push('b');
-        bag.push('c');
-        bag.push('d');
-
-        assert_eq!(
-            vec!['a', 'b', 'c', 'd'],
-            bag.iter().copied().collect::<Vec<_>>()
-        );
-
-        bag.clear();
-        assert_eq!(0, bag.iter().count());
-    }
-
-    #[test]
-    fn into_inner_from() {
-        let bag = ConcurrentVec::new();
-
-        bag.push('a');
-        bag.push('b');
-        bag.push('c');
-        bag.push('d');
-        assert_eq!(
-            vec!['a', 'b', 'c', 'd'],
-            bag.iter().copied().collect::<Vec<_>>()
-        );
-
-        let mut split = bag.into_inner();
-        assert_eq!(
-            vec!['a', 'b', 'c', 'd'],
-            split.iter().flatten().copied().collect::<Vec<_>>()
-        );
-
-        split.push(Some('e'));
-        *split.get_mut(0).expect("exists") = Some('x');
-
-        assert_eq!(
-            vec!['x', 'b', 'c', 'd', 'e'],
-            split.iter().flatten().copied().collect::<Vec<_>>()
-        );
-
-        let mut bag: ConcurrentVec<_> = split.into();
-        assert_eq!(
-            vec!['x', 'b', 'c', 'd', 'e'],
-            bag.iter().copied().collect::<Vec<_>>()
-        );
-
-        bag.clear();
-        assert!(bag.is_empty());
-
-        let split = bag.into_inner();
-        assert!(split.is_empty());
-    }
-
-    #[test]
-    fn ok_at_num_threads() {
-        use std::thread::available_parallelism;
-        let default_parallelism_approx = available_parallelism().expect("is-ok").get();
-        dbg!(default_parallelism_approx);
-
-        let num_threads = default_parallelism_approx;
-        let num_items_per_thread = 16384;
-
-        let bag = ConcurrentVec::new();
-        let bag_ref = &bag;
-        std::thread::scope(|s| {
-            for i in 0..num_threads {
-                s.spawn(move || {
-                    for j in 0..num_items_per_thread {
-                        bag_ref.push((i * 100000 + j) as i32);
-                    }
-                });
-            }
-        });
-
-        let pinned = bag.into_inner();
-        assert_eq!(pinned.len(), num_threads * num_items_per_thread);
-    }
-
-    #[test]
-    fn push_indices() {
-        let num_threads = 4;
-        let num_items_per_thread = 16;
-
-        let indices_set = Arc::new(Mutex::new(HashSet::new()));
-
-        let bag = ConcurrentVec::new();
-        let bag_ref = &bag;
-        std::thread::scope(|s| {
-            for i in 0..num_threads {
-                let indices_set = indices_set.clone();
-                s.spawn(move || {
-                    for j in 0..num_items_per_thread {
-                        let idx = bag_ref.push(i * 100000 + j);
-                        let mut set = indices_set.lock().expect("is ok");
-                        set.insert(idx);
-                    }
-                });
-            }
-        });
-
-        let set = indices_set.lock().expect("is ok");
-        assert_eq!(set.len(), 4 * 16);
-        for i in 0..(4 * 16) {
-            assert!(set.contains(&i));
-        }
-    }
-
-    #[test]
-    fn reserve_maximum_capacity() {
-        // SplitVec<_, Doubling>
-        let bag: ConcurrentVec<char> = ConcurrentVec::new();
-        assert_eq!(bag.capacity(), 4); // only allocates the first fragment of 4
-        assert_eq!(bag.maximum_capacity(), 17_179_869_180); // it can grow safely & exponentially
-
-        let bag: ConcurrentVec<char, _> = ConcurrentVec::with_doubling_growth();
-        assert_eq!(bag.capacity(), 4);
-        assert_eq!(bag.maximum_capacity(), 17_179_869_180);
-
-        // SplitVec<_, Linear>
-        let mut bag: ConcurrentVec<char, _> = ConcurrentVec::with_linear_growth(10, 20);
-        assert_eq!(bag.capacity(), 2usize.pow(10)); // only allocates first fragment of 1024
-        assert_eq!(bag.maximum_capacity(), 2usize.pow(10) * 20); // it can concurrently allocate 19 more
-
-        // SplitVec<_, Linear> -> reserve_maximum_capacity
-        let result = bag.reserve_maximum_capacity(2usize.pow(10) * 30);
-        assert_eq!(result, Ok(2usize.pow(10) * 30));
-
-        // actually no new allocation yet; precisely additional memory for 10 pairs of pointers is used
-        assert_eq!(bag.capacity(), 2usize.pow(10)); // first fragment capacity
-
-        dbg!(bag.maximum_capacity(), 2usize.pow(10) * 30);
-        assert_eq!(bag.maximum_capacity(), 2usize.pow(10) * 30); // now it can safely reach 2^10 * 30
-
-        // FixedVec<_>: pre-allocated, exact and strict
-        let mut bag: ConcurrentVec<char, _> = ConcurrentVec::with_fixed_capacity(42);
-        assert_eq!(bag.capacity(), 42);
-        assert_eq!(bag.maximum_capacity(), 42);
-
-        let result = bag.reserve_maximum_capacity(43);
-        assert_eq!(
-            result,
-            Err(PinnedVecGrowthError::FailedToGrowWhileKeepingElementsPinned)
-        );
-    }
-
-    #[test]
-    fn extend_indices() {
-        let num_threads = 4;
-        let num_items_per_thread = 16;
-
-        let indices_set = Arc::new(Mutex::new(HashSet::new()));
-
-        let bag = ConcurrentVec::new();
-        let bag_ref = &bag;
-        std::thread::scope(|s| {
-            for i in 0..num_threads {
-                let indices_set = indices_set.clone();
-                s.spawn(move || {
-                    let iter = (0..num_items_per_thread).map(|j| i * 100000 + j);
-
-                    let begin_idx = bag_ref.extend(iter);
-
-                    let mut set = indices_set.lock().expect("is ok");
-                    set.insert(begin_idx);
-                });
-            }
-        });
-
-        let set = indices_set.lock().expect("is ok");
-        assert_eq!(set.len(), num_threads);
-        for i in 0..num_threads {
-            assert!(set.contains(&(i * num_items_per_thread)));
-        }
-    }
-
-    #[test]
-    fn extend_n_items_indices() {
-        let num_threads = 4;
-        let num_items_per_thread = 16;
-
-        let indices_set = Arc::new(Mutex::new(HashSet::new()));
-
-        let bag = ConcurrentVec::new();
-        let bag_ref = &bag;
-        std::thread::scope(|s| {
-            for i in 0..num_threads {
-                let indices_set = indices_set.clone();
-                s.spawn(move || {
-                    let iter = (0..num_items_per_thread).map(|j| i * 100000 + j);
-
-                    let begin_idx = unsafe { bag_ref.extend_n_items(iter, num_items_per_thread) };
-
-                    let mut set = indices_set.lock().expect("is ok");
-                    set.insert(begin_idx);
-                });
-            }
-        });
-
-        let set = indices_set.lock().expect("is ok");
-        assert_eq!(set.len(), num_threads);
-        for i in 0..num_threads {
-            assert!(set.contains(&(i * num_items_per_thread)));
-        }
-    }
-}

--- a/tests/concurrent_vec.rs
+++ b/tests/concurrent_vec.rs
@@ -1,0 +1,158 @@
+use orx_concurrent_vec::*;
+use std::{
+    collections::HashSet,
+    sync::{Arc, Mutex},
+};
+
+#[test]
+fn into_inner_from() {
+    let bag = ConcurrentVec::new();
+
+    bag.push('a');
+    bag.push('b');
+    bag.push('c');
+    bag.push('d');
+    assert_eq!(
+        vec!['a', 'b', 'c', 'd'],
+        bag.iter().copied().collect::<Vec<_>>()
+    );
+
+    let mut split = bag.into_inner();
+    assert_eq!(
+        vec!['a', 'b', 'c', 'd'],
+        split.iter().copied().flatten().collect::<Vec<_>>()
+    );
+
+    split.push(Some('e'));
+    *split.get_mut(0).expect("exists") = Some('x');
+
+    assert_eq!(
+        vec!['x', 'b', 'c', 'd', 'e'],
+        split.iter().copied().flatten().collect::<Vec<_>>()
+    );
+
+    let mut bag: ConcurrentVec<_> = split.into();
+    assert_eq!(
+        vec!['x', 'b', 'c', 'd', 'e'],
+        bag.iter().copied().collect::<Vec<_>>()
+    );
+
+    bag.clear();
+    assert!(bag.is_empty());
+
+    let split = bag.into_inner();
+    assert!(split.is_empty());
+}
+
+#[test]
+fn ok_at_num_threads() {
+    use std::thread::available_parallelism;
+    let default_parallelism_approx = available_parallelism().expect("is-ok").get();
+
+    let num_threads = default_parallelism_approx;
+    let num_items_per_thread = 16384;
+
+    let bag = ConcurrentVec::new();
+    let bag_ref = &bag;
+    std::thread::scope(|s| {
+        for i in 0..num_threads {
+            s.spawn(move || {
+                for j in 0..num_items_per_thread {
+                    bag_ref.push((i * 100000 + j) as i32);
+                }
+            });
+        }
+    });
+
+    let pinned = bag.into_inner();
+    assert_eq!(pinned.len(), num_threads * num_items_per_thread);
+}
+
+#[test]
+fn push_indices() {
+    let num_threads = 4;
+    let num_items_per_thread = 16;
+
+    let indices_set = Arc::new(Mutex::new(HashSet::new()));
+
+    let bag = ConcurrentVec::new();
+    let bag_ref = &bag;
+    std::thread::scope(|s| {
+        for i in 0..num_threads {
+            let indices_set = indices_set.clone();
+            s.spawn(move || {
+                for j in 0..num_items_per_thread {
+                    let idx = bag_ref.push(i * 100000 + j);
+                    let mut set = indices_set.lock().expect("is ok");
+                    set.insert(idx);
+                }
+            });
+        }
+    });
+
+    let set = indices_set.lock().expect("is ok");
+    assert_eq!(set.len(), 4 * 16);
+    for i in 0..(4 * 16) {
+        assert!(set.contains(&i));
+    }
+}
+
+#[test]
+fn extend_indices() {
+    let num_threads = 4;
+    let num_items_per_thread = 16;
+
+    let indices_set = Arc::new(Mutex::new(HashSet::new()));
+
+    let bag = ConcurrentVec::new();
+    let bag_ref = &bag;
+    std::thread::scope(|s| {
+        for i in 0..num_threads {
+            let indices_set = indices_set.clone();
+            s.spawn(move || {
+                let iter = (0..num_items_per_thread).map(|j| i * 100000 + j);
+
+                let begin_idx = bag_ref.extend(iter);
+
+                let mut set = indices_set.lock().expect("is ok");
+                set.insert(begin_idx);
+            });
+        }
+    });
+
+    let set = indices_set.lock().expect("is ok");
+    assert_eq!(set.len(), num_threads);
+    for i in 0..num_threads {
+        assert!(set.contains(&(i * num_items_per_thread)));
+    }
+}
+
+#[test]
+fn extend_n_items_indices() {
+    let num_threads = 4;
+    let num_items_per_thread = 16;
+
+    let indices_set = Arc::new(Mutex::new(HashSet::new()));
+
+    let bag = ConcurrentVec::new();
+    let bag_ref = &bag;
+    std::thread::scope(|s| {
+        for i in 0..num_threads {
+            let indices_set = indices_set.clone();
+            s.spawn(move || {
+                let iter = (0..num_items_per_thread).map(|j| i * 100000 + j);
+
+                let begin_idx = unsafe { bag_ref.extend_n_items(iter, num_items_per_thread) };
+
+                let mut set = indices_set.lock().expect("is ok");
+                set.insert(begin_idx);
+            });
+        }
+    });
+
+    let set = indices_set.lock().expect("is ok");
+    assert_eq!(set.len(), num_threads);
+    for i in 0..num_threads {
+        assert!(set.contains(&(i * num_items_per_thread)));
+    }
+}

--- a/tests/drop.rs
+++ b/tests/drop.rs
@@ -1,0 +1,59 @@
+use orx_concurrent_vec::*;
+use test_case::test_matrix;
+
+#[test_matrix(
+    [
+        FixedVec::new(100000),
+        SplitVec::with_doubling_growth_and_fragments_capacity(32),
+        SplitVec::with_recursive_growth_and_fragments_capacity(32),
+        SplitVec::with_linear_growth_and_fragments_capacity(10, 64),
+    ],
+    [124, 348, 1024, 2587, 42578]
+)]
+fn dropped_as_bag<P: PinnedVec<Option<String>>>(pinned_vec: P, len: usize) {
+    let num_threads = 4;
+    let num_items_per_thread = len / num_threads;
+
+    let bag = fill_bag(pinned_vec, len);
+
+    assert_eq!(bag.len(), num_threads * num_items_per_thread);
+}
+
+#[test_matrix(
+    [
+        FixedVec::new(100000),
+        SplitVec::with_doubling_growth_and_fragments_capacity(32),
+        SplitVec::with_recursive_growth_and_fragments_capacity(32),
+        SplitVec::with_linear_growth_and_fragments_capacity(10, 64),
+    ],
+    [124, 348, 1024, 2587, 42578]
+)]
+fn dropped_after_into_inner<P: PinnedVec<Option<String>>>(pinned_vec: P, len: usize) {
+    let num_threads = 4;
+    let num_items_per_thread = len / num_threads;
+
+    let bag = fill_bag(pinned_vec, len);
+
+    let inner = bag.into_inner();
+    assert_eq!(inner.len(), num_threads * num_items_per_thread);
+}
+
+fn fill_bag<P: PinnedVec<Option<String>>>(pinned_vec: P, len: usize) -> ConcurrentVec<String, P> {
+    let num_threads = 4;
+    let num_items_per_thread = len / num_threads;
+
+    let bag: ConcurrentVec<_, _> = pinned_vec.into();
+    let con_bag = &bag;
+    std::thread::scope(move |s| {
+        for _ in 0..num_threads {
+            s.spawn(move || {
+                for value in 0..num_items_per_thread {
+                    let new_value = format!("from-thread-{}", value);
+                    con_bag.push(new_value);
+                }
+            });
+        }
+    });
+
+    bag
+}

--- a/tests/new.rs
+++ b/tests/new.rs
@@ -1,0 +1,36 @@
+use orx_concurrent_vec::*;
+
+#[test]
+fn new_len_empty_clear() {
+    fn test<P: PinnedVec<Option<char>>>(bag: ConcurrentVec<char, P>) {
+        assert!(!bag.zeroes_memory_on_allocation());
+
+        let mut bag = bag;
+
+        assert!(bag.is_empty());
+        assert_eq!(0, bag.len());
+
+        bag.push('a');
+
+        assert!(!bag.is_empty());
+        assert_eq!(1, bag.len());
+
+        bag.push('b');
+        bag.push('c');
+        bag.push('d');
+
+        assert!(!bag.is_empty());
+        assert_eq!(4, bag.len());
+
+        bag.clear();
+        assert!(bag.is_empty());
+        assert_eq!(0, bag.len());
+    }
+
+    test(ConcurrentVec::new());
+    test(ConcurrentVec::default());
+    test(ConcurrentVec::with_doubling_growth());
+    test(ConcurrentVec::with_linear_growth(2, 8));
+    test(ConcurrentVec::with_linear_growth(4, 8));
+    test(ConcurrentVec::with_fixed_capacity(64));
+}

--- a/tests/pinned_concurrent_col.rs
+++ b/tests/pinned_concurrent_col.rs
@@ -1,0 +1,176 @@
+use orx_concurrent_vec::*;
+use std::time::Duration;
+
+#[test]
+fn capacity() {
+    let mut split: SplitVec<_, Doubling> = (0..4).map(Some).collect();
+    split.concurrent_reserve(5).expect("is-ok");
+    let bag: ConcurrentVec<_, _> = split.into();
+    assert_eq!(bag.capacity(), 4);
+    bag.push(42);
+    assert_eq!(bag.capacity(), 12);
+
+    let mut split: SplitVec<_, Recursive> = (0..4).map(Some).collect();
+    split.concurrent_reserve(5).expect("is-ok");
+    let bag: ConcurrentVec<_, _> = split.into();
+    assert_eq!(bag.capacity(), 4);
+    bag.push(42);
+    assert_eq!(bag.capacity(), 12);
+
+    let mut split: SplitVec<_, Linear> = SplitVec::with_linear_growth(2);
+    split.extend_from_slice(&[0, 1, 2, 3].map(Some));
+    split.concurrent_reserve(5).expect("is-ok");
+    let bag: ConcurrentVec<_, _> = split.into();
+    assert_eq!(bag.capacity(), 4);
+    bag.push(42);
+    assert_eq!(bag.capacity(), 8);
+
+    let mut fixed: FixedVec<_> = FixedVec::new(5);
+    fixed.extend_from_slice(&[0, 1, 2, 3].map(Some));
+    let bag: ConcurrentVec<_, _> = fixed.into();
+    assert_eq!(bag.capacity(), 5);
+    bag.push(42);
+    assert_eq!(bag.capacity(), 5);
+}
+
+#[test]
+#[should_panic]
+fn exceeding_fixed_capacity_panics() {
+    let mut fixed: FixedVec<_> = FixedVec::new(5);
+    fixed.extend_from_slice(&[0, 1, 2, 3].map(Some));
+    let bag: ConcurrentVec<_, _> = fixed.into();
+    assert_eq!(bag.capacity(), 5);
+    bag.push(42);
+    bag.push(7);
+}
+
+#[test]
+#[should_panic]
+fn exceeding_fixed_capacity_panics_concurrently() {
+    let bag = ConcurrentVec::with_fixed_capacity(10);
+    let bag_ref = &bag;
+    std::thread::scope(|s| {
+        for _ in 0..4 {
+            s.spawn(move || {
+                for _ in 0..3 {
+                    // in total there will be 4*3 = 12 pushes
+                    bag_ref.push(42);
+                }
+            });
+        }
+    });
+}
+
+#[test]
+fn get() {
+    // record measurements in (assume) random intervals
+    let measurements = ConcurrentVec::<i32>::new();
+    let rf_measurements = &measurements;
+
+    // collect sum of measurements every 50 milliseconds
+    let sums = ConcurrentVec::new();
+    let rf_sums = &sums;
+
+    // collect average of measurements every 50 milliseconds
+    let averages = ConcurrentVec::new();
+    let rf_averages = &averages;
+
+    std::thread::scope(|s| {
+        s.spawn(move || {
+            for i in 0..100 {
+                std::thread::sleep(Duration::from_millis(i % 5));
+                rf_measurements.push(i as i32);
+            }
+        });
+
+        s.spawn(move || {
+            for _ in 0..10 {
+                let mut sum = 0;
+                for i in 0..rf_measurements.len() {
+                    sum += rf_measurements.get(i).copied().unwrap_or(0);
+                }
+                rf_sums.push(sum);
+                std::thread::sleep(Duration::from_millis(50));
+            }
+        });
+
+        s.spawn(move || {
+            for _ in 0..10 {
+                let count = rf_measurements.len();
+                if count == 0 {
+                    rf_averages.push(0.0);
+                } else {
+                    let mut sum = 0;
+                    for i in 0..rf_measurements.len() {
+                        sum += rf_measurements.get(i).copied().unwrap_or(0);
+                    }
+                    let average = sum as f32 / count as f32;
+                    rf_averages.push(average);
+                }
+                std::thread::sleep(Duration::from_millis(50));
+            }
+        });
+    });
+
+    assert_eq!(measurements.len(), 100);
+    assert_eq!(sums.len(), 10);
+    assert_eq!(averages.len(), 10);
+}
+
+#[test]
+fn iter() {
+    let mut bag = ConcurrentVec::new();
+
+    assert_eq!(0, bag.iter().count());
+
+    bag.push('a');
+
+    assert_eq!(vec!['a'], bag.iter().copied().collect::<Vec<_>>());
+
+    bag.push('b');
+    bag.push('c');
+    bag.push('d');
+
+    assert_eq!(
+        vec!['a', 'b', 'c', 'd'],
+        bag.iter().copied().collect::<Vec<_>>()
+    );
+
+    bag.clear();
+    assert_eq!(0, bag.iter().count());
+}
+
+#[test]
+fn reserve_maximum_capacity() {
+    // SplitVec<_, Doubling>
+    let bag: ConcurrentVec<char> = ConcurrentVec::new();
+    assert_eq!(bag.capacity(), 4); // only allocates the first fragment of 4
+    assert_eq!(bag.maximum_capacity(), 17_179_869_180); // it can grow safely & exponentially
+
+    let bag: ConcurrentVec<char, _> = ConcurrentVec::with_doubling_growth();
+    assert_eq!(bag.capacity(), 4);
+    assert_eq!(bag.maximum_capacity(), 17_179_869_180);
+
+    // SplitVec<_, Linear>
+    let mut bag: ConcurrentVec<char, _> = ConcurrentVec::with_linear_growth(10, 20);
+    assert_eq!(bag.capacity(), 2usize.pow(10)); // only allocates first fragment of 1024
+    assert_eq!(bag.maximum_capacity(), 2usize.pow(10) * 20); // it can concurrently allocate 19 more
+
+    // SplitVec<_, Linear> -> reserve_maximum_capacity
+    let result = bag.reserve_maximum_capacity(2usize.pow(10) * 30);
+    assert!(result.is_ok());
+    assert!(result.expect("is-ok") >= 2usize.pow(10) * 30);
+
+    // actually no new allocation yet; precisely additional memory for 10 pairs of pointers is used
+    assert_eq!(bag.capacity(), 2usize.pow(10)); // first fragment capacity
+
+    assert!(bag.maximum_capacity() >= 2usize.pow(10) * 30); // now it can safely reach 2^10 * 30
+
+    // FixedVec<_>: pre-allocated, exact and strict
+    let mut bag: ConcurrentVec<char, _> = ConcurrentVec::with_fixed_capacity(42);
+    assert_eq!(bag.capacity(), 42);
+    assert_eq!(bag.maximum_capacity(), 42);
+
+    let result = bag.reserve_maximum_capacity(43);
+    assert!(result.is_err());
+}


### PR DESCRIPTION
`ConcurrentVec` now is only a wrapper around a `ConcurrentBag` with safe get and iter implementations.
* `ConcurrentBag` implements `Deref` and `DerefMut` for `PinnedConcurrentCol `. And `ConcurrentVec` for `ConcurrentBag `.
* Documentation is revised.
* Benchmarks are repeated, performance has not changed (as expected).