### PR TITLE
concurrency-model-revised

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-concurrent-vec"
-version = "1.10.0"
+version = "2.0.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "An efficient, convenient and lightweight grow-only read & write concurrent data structure allowing high performance concurrent collection."
@@ -10,13 +10,15 @@ keywords = ["concurrency", "vec", "data-structures", "atomic", "lock-free"]
 categories = ["data-structures", "concurrency", "rust-patterns"]
 
 [dependencies]
-orx-concurrent-bag = "1.16"
-orx-fixed-vec = "2.12"
-orx-pinned-concurrent-col = "1.6"
-orx-pinned-vec = "2.12"
-orx-split-vec = "2.14"
+orx-pseudo-default = "1.0"
+orx-fixed-vec = "3.0"
+orx-pinned-vec = "3.0"
+orx-split-vec = "3.0"
+orx-pinned-concurrent-col = "2.0"
+orx-concurrent-ordered-bag = "2.0"
 
 [dev-dependencies]
+orx-concurrent-bag = "2.0"
 criterion = "0.5.1"
 rand = "0.8.5"
 rayon = "1.9.0"

--- a/README.md
+++ b/README.md
@@ -104,25 +104,25 @@ Further, there exist `with_` methods to directly construct the concurrent bag wi
 ```rust
 use orx_concurrent_vec::*;
 
-// default pinned vector -> SplitVec<Option<T>, Doubling>
+// default pinned vector -> SplitVec<T, Doubling>
 let con_vec: ConcurrentVec<char> = ConcurrentVec::new();
 let con_vec: ConcurrentVec<char> = Default::default();
 let con_vec: ConcurrentVec<char> = ConcurrentVec::with_doubling_growth();
-let con_vec: ConcurrentVec<char, SplitVec<Option<char>, Doubling>> = ConcurrentVec::with_doubling_growth();
+let con_vec: ConcurrentVec<char, SplitVec<char, Doubling>> = ConcurrentVec::with_doubling_growth();
 
 let con_vec: ConcurrentVec<char> = SplitVec::new().into();
-let con_vec: ConcurrentVec<char, SplitVec<Option<char>, Doubling>> = SplitVec::new().into();
+let con_vec: ConcurrentVec<char, SplitVec<char, Doubling>> = SplitVec::new().into();
 
 // SplitVec with [Linear](https://docs.rs/orx-split-vec/latest/orx_split_vec/struct.Linear.html) growth
 // each fragment will have capacity 2^10 = 1024
 // and the split vector can grow up to 32 fragments
-let con_vec: ConcurrentVec<char, SplitVec<Option<char>, Linear>> = ConcurrentVec::with_linear_growth(10, 32);
-let con_vec: ConcurrentVec<char, SplitVec<Option<char>, Linear>> = SplitVec::with_linear_growth_and_fragments_capacity(10, 32).into();
+let con_vec: ConcurrentVec<char, SplitVec<char, Linear>> = ConcurrentVec::with_linear_growth(10, 32);
+let con_vec: ConcurrentVec<char, SplitVec<char, Linear>> = SplitVec::with_linear_growth_and_fragments_capacity(10, 32).into();
 
 // [FixedVec](https://docs.rs/orx-fixed-vec/latest/orx_fixed_vec/) with fixed capacity.
 // Fixed vector cannot grow; hence, pushing the 1025-th element to this concurrent vector will cause a panic!
-let con_vec: ConcurrentVec<char, FixedVec<Option<char>>> = ConcurrentVec::with_fixed_capacity(1024);
-let con_vec: ConcurrentVec<char, FixedVec<Option<char>>> = FixedVec::new(1024).into();
+let con_vec: ConcurrentVec<char, FixedVec<char>> = ConcurrentVec::with_fixed_capacity(1024);
+let con_vec: ConcurrentVec<char, FixedVec<char>> = FixedVec::new(1024).into();
 ```
 
 Of course, the pinned vector to be wrapped does not need to be empty.
@@ -130,7 +130,7 @@ Of course, the pinned vector to be wrapped does not need to be empty.
 ```rust
 use orx_concurrent_vec::*;
 
-let split_vec: SplitVec<Option<i32>> = (0..1024).map(Some).collect();
+let split_vec: SplitVec<i32> = (0..1024).collect();
 let con_vec: ConcurrentVec<_> = split_vec.into();
 ```
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,6 @@ std::thread::scope(|s| {
 let measurements: Vec<_> = measurements
     .into_inner()
     .into_iter()
-    .map(|x| x.unwrap())
     .collect();
 dbg!(&measurements);
 
@@ -96,7 +95,7 @@ assert_eq!(averages.len(), 10);
 
 ### Construction
 
-`ConcurrentVec` can be constructed by wrapping any pinned vector; i.e., `ConcurrentVec<T>` implements `From<P: PinnedVec<Option<T>>>`.
+`ConcurrentVec` can be constructed by wrapping any pinned vector implementing `IntoConcurrentPinnedVec`.
 Likewise, a concurrent vector can be unwrapped to get the underlying pinned vector with `into_inner` method.
 
 Further, there exist `with_` methods to directly construct the concurrent bag with common pinned vector implementations.
@@ -142,7 +141,7 @@ The concurrent state is modeled simply by an atomic length. Combination of this 
 * ⟹ no write & write race condition exists.
 * Only one growth can happen at a given time. Growth is copy-free and does not change memory locations of already pushed elements.
 * Underlying pinned vector is always valid and can be taken out any time by `into_inner(self)`.
-* Reading a position while its being written will yield `None` and will be omitted. If the element has been properly initialized, the other threads will safely read `Some(T)`.
+* Attempting to read from a position while its value is being written will yield `None` and will be omitted. If the element has been properly initialized, the other threads will safely read `Some(T)`.
 * In other words, a position will be written exactly once, but can be read multiple times concurrently. However, reading can only happen after it is completely written.
 
 
@@ -150,11 +149,10 @@ The concurrent state is modeled simply by an atomic length. Combination of this 
 
 ||[`ConcurrentBag`](https://crates.io/crates/orx-concurrent-bag)|[`ConcurrentVec`](https://crates.io/crates/orx-concurrent-vec)|[`ConcurrentOrderedBag`](https://crates.io/crates/orx-concurrent-ordered-bag)|
 |---|---|---|---|
-| Underlying Storage | Directly in a `PinnedVec<T>` | Elements are wrapped with optional; i.e., stored in a `PinnedVec<Option<T>>` | Directly in a `PinnedVec<T>` |
 | Write | Guarantees that each element is written exactly once via `push` or `extend` methods | Guarantees that each element is written exactly once via `push` or `extend` methods | Different in two ways. First, a position can be written multiple times. Second, an arbitrary element of the bag can be written at any time at any order using `set_value` and `set_values` methods. This provides a great flexibility while moving the safety responsibility to the caller; hence, the set methods are `unsafe`. |
 | Read | Mainly, a write-only collection. Concurrent reading of already pushed elements is through `unsafe` `get` and `iter` methods. The caller is required to avoid race conditions. | A write-and-read collection. Already pushed elements can safely be read through `get` and `iter` methods. | Not supported currently. Due to the flexible but unsafe nature of write operations, it is difficult to provide required safety guarantees as a caller. |
 | Ordering of Elements | Since write operations are through adding elements to the end of the pinned vector via `push` and `extend`, two multi-threaded executions of a code that collects elements into the bag might result in the elements being collected in different orders. | Since write operations are through adding elements to the end of the pinned vector via `push` and `extend`, two multi-threaded executions of a code that collects elements into the bag might result in the elements being collected in different orders. | This is the main goal of this collection, allowing to collect elements concurrently and in the correct order. Although this does not seem trivial; it can be achieved almost trivially when `ConcurrentOrderedBag` is used together with a [`ConcurrentIter`](https://crates.io/crates/orx-concurrent-iter). |
-| `into_inner` | Once the concurrent collection is completed, the bag can safely be converted to its underlying `PinnedVec<T>` without a cost. | Once the concurrent collection is completed, the bag can safely be converted to its underlying `PinnedVec<Option<T>>` of option-wrapped elements without a cost. | Growing through flexible setters allowing to write to any position, `ConcurrentOrderedBag` has the risk of containing gaps. `into_inner` call provides some useful metrics such as whether the number of elements pushed elements match the  maximum index of the vector; however, it cannot guarantee that the bag is gap-free. The caller is required to take responsibility to unwrap to get the underlying `PinnedVec<T>` through an `unsafe` call. |
+| `into_inner` | Once the concurrent collection is completed, the bag can safely be converted to its underlying `PinnedVec<T>`. | Once the concurrent collection is completed, the bag can safely be converted to its underlying `PinnedVec<T>`. | Growing through flexible setters allowing to write to any position, `ConcurrentOrderedBag` has the risk of containing gaps. `into_inner` call provides some useful metrics such as whether the number of elements pushed elements match the  maximum index of the vector; however, it cannot guarantee that the bag is gap-free. The caller is required to take responsibility to unwrap to get the underlying `PinnedVec<T>` through an `unsafe` call. |
 |||||
 
 <div id="section-benchmarks"></div>
@@ -163,9 +161,9 @@ The concurrent state is modeled simply by an atomic length. Combination of this 
 
 *You may find the details of the benchmarks at [benches/collect_with_push.rs](https://github.com/orxfun/orx-concurrent-vec/blob/main/benches/collect_with_push.rs) and [benches/collect_with_extend.rs](https://github.com/orxfun/orx-concurrent-vec/blob/main/benches/collect_with_extend.rs).*
 
-Please see results of benchmarks in the concurrent bag documentation, [here](https://docs.rs/orx-concurrent-bag/latest/orx_concurrent_bag/#section-benchmarks), since no significant impact of the `Option` wrapper is observed and benchmark results are almost identical. In summary:
+Please see results of benchmarks in the concurrent bag documentation [here](https://docs.rs/orx-concurrent-bag/latest/orx_concurrent_bag/#section-benchmarks). In summary:
 
-* Concurrent bag and concurrent vec provide a very high performance collection.
+* Concurrent bag and concurrent vec provide a high performance collection.
 * Importantly, using `extend` rather than `push` provides further significant performance improvements as it allows to avoid a problem known as *false sharing*. Please see the relevant section [here](https://docs.rs/orx-concurrent-bag/latest/orx_concurrent_bag/#section-performance-notes) for details.
 
 ## Contributing

--- a/benches/collect_with_extend.rs
+++ b/benches/collect_with_extend.rs
@@ -30,7 +30,7 @@ fn compute_large_data(i: usize, j: usize) -> LargeData {
     LargeData { a }
 }
 
-fn with_concurrent_vec<T: Sync, P: PinnedVec<Option<T>>>(
+fn with_concurrent_vec<T: Sync, P: IntoConcurrentPinnedVec<T>>(
     num_threads: usize,
     num_items_per_thread: usize,
     compute: fn(usize, usize) -> T,

--- a/benches/collect_with_push.rs
+++ b/benches/collect_with_push.rs
@@ -30,7 +30,7 @@ fn compute_large_data(i: usize, j: usize) -> LargeData {
     LargeData { a }
 }
 
-fn with_concurrent_vec<T: Sync, P: PinnedVec<Option<T>>>(
+fn with_concurrent_vec<T: Sync, P: IntoConcurrentPinnedVec<T>>(
     num_threads: usize,
     num_items_per_thread: usize,
     compute: fn(usize, usize) -> T,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,7 +83,6 @@
 //! let measurements: Vec<_> = measurements
 //!     .into_inner()
 //!     .into_iter()
-//!     .map(|x| x.unwrap())
 //!     .collect();
 //! dbg!(&measurements);
 //!
@@ -104,25 +103,25 @@
 //! ```rust
 //! use orx_concurrent_vec::*;
 //!
-//! // default pinned vector -> SplitVec<Option<T>, Doubling>
+//! // default pinned vector -> SplitVec<T, Doubling>
 //! let con_vec: ConcurrentVec<char> = ConcurrentVec::new();
 //! let con_vec: ConcurrentVec<char> = Default::default();
 //! let con_vec: ConcurrentVec<char> = ConcurrentVec::with_doubling_growth();
-//! let con_vec: ConcurrentVec<char, SplitVec<Option<char>, Doubling>> = ConcurrentVec::with_doubling_growth();
+//! let con_vec: ConcurrentVec<char, SplitVec<char, Doubling>> = ConcurrentVec::with_doubling_growth();
 //!
 //! let con_vec: ConcurrentVec<char> = SplitVec::new().into();
-//! let con_vec: ConcurrentVec<char, SplitVec<Option<char>, Doubling>> = SplitVec::new().into();
+//! let con_vec: ConcurrentVec<char, SplitVec<char, Doubling>> = SplitVec::new().into();
 //!
 //! // SplitVec with [Linear](https://docs.rs/orx-split-vec/latest/orx_split_vec/struct.Linear.html) growth
 //! // each fragment will have capacity 2^10 = 1024
 //! // and the split vector can grow up to 32 fragments
-//! let con_vec: ConcurrentVec<char, SplitVec<Option<char>, Linear>> = ConcurrentVec::with_linear_growth(10, 32);
-//! let con_vec: ConcurrentVec<char, SplitVec<Option<char>, Linear>> = SplitVec::with_linear_growth_and_fragments_capacity(10, 32).into();
+//! let con_vec: ConcurrentVec<char, SplitVec<char, Linear>> = ConcurrentVec::with_linear_growth(10, 32);
+//! let con_vec: ConcurrentVec<char, SplitVec<char, Linear>> = SplitVec::with_linear_growth_and_fragments_capacity(10, 32).into();
 //!
 //! // [FixedVec](https://docs.rs/orx-fixed-vec/latest/orx_fixed_vec/) with fixed capacity.
 //! // Fixed vector cannot grow; hence, pushing the 1025-th element to this concurrent vector will cause a panic!
-//! let con_vec: ConcurrentVec<char, FixedVec<Option<char>>> = ConcurrentVec::with_fixed_capacity(1024);
-//! let con_vec: ConcurrentVec<char, FixedVec<Option<char>>> = FixedVec::new(1024).into();
+//! let con_vec: ConcurrentVec<char, FixedVec<char>> = ConcurrentVec::with_fixed_capacity(1024);
+//! let con_vec: ConcurrentVec<char, FixedVec<char>> = FixedVec::new(1024).into();
 //! ```
 //!
 //! Of course, the pinned vector to be wrapped does not need to be empty.
@@ -130,7 +129,7 @@
 //! ```rust
 //! use orx_concurrent_vec::*;
 //!
-//! let split_vec: SplitVec<Option<i32>> = (0..1024).map(Some).collect();
+//! let split_vec: SplitVec<i32> = (0..1024).collect();
 //! let con_vec: ConcurrentVec<_> = split_vec.into();
 //! ```
 //!
@@ -188,10 +187,17 @@
     clippy::todo
 )]
 
+mod mask;
 mod new;
+mod state;
 mod vec;
 
+/// Common relevant traits, structs, enums.
+pub mod prelude;
+
 pub use orx_fixed_vec::FixedVec;
-pub use orx_pinned_vec::PinnedVec;
-pub use orx_split_vec::{Doubling, Linear, Recursive, SplitVec};
+pub use orx_pinned_vec::{
+    ConcurrentPinnedVec, IntoConcurrentPinnedVec, PinnedVec, PinnedVecGrowthError,
+};
+pub use orx_split_vec::{Doubling, Linear, SplitVec};
 pub use vec::ConcurrentVec;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,7 +95,7 @@
 //!
 //! ### Construction
 //!
-//! `ConcurrentVec` can be constructed by wrapping any pinned vector; i.e., `ConcurrentVec<T>` implements `From<P: PinnedVec<Option<T>>>`.
+//! `ConcurrentVec` can be constructed by wrapping any pinned vector implementing `IntoConcurrentPinnedVec`.
 //! Likewise, a concurrent vector can be unwrapped to get the underlying pinned vector with `into_inner` method.
 //!
 //! Further, there exist `with_` methods to directly construct the concurrent bag with common pinned vector implementations.
@@ -141,7 +141,7 @@
 //! * ⟹ no write & write race condition exists.
 //! * Only one growth can happen at a given time. Growth is copy-free and does not change memory locations of already pushed elements.
 //! * Underlying pinned vector is always valid and can be taken out any time by `into_inner(self)`.
-//! * Reading a position while its being written will yield `None` and will be omitted. If the element has been properly initialized, the other threads will safely read `Some(T)`.
+//! * Attempting to read from a position while its value is being written will yield `None` and will be omitted. If the element has been properly initialized, the other threads will safely read `Some(T)`.
 //! * In other words, a position will be written exactly once, but can be read multiple times concurrently. However, reading can only happen after it is completely written.
 //!
 //!
@@ -149,11 +149,10 @@
 //!
 //! ||[`ConcurrentBag`](https://crates.io/crates/orx-concurrent-bag)|[`ConcurrentVec`](https://crates.io/crates/orx-concurrent-vec)|[`ConcurrentOrderedBag`](https://crates.io/crates/orx-concurrent-ordered-bag)|
 //! |---|---|---|---|
-//! | Underlying Storage | Directly in a `PinnedVec<T>` | Elements are wrapped with optional; i.e., stored in a `PinnedVec<Option<T>>` | Directly in a `PinnedVec<T>` |
 //! | Write | Guarantees that each element is written exactly once via `push` or `extend` methods | Guarantees that each element is written exactly once via `push` or `extend` methods | Different in two ways. First, a position can be written multiple times. Second, an arbitrary element of the bag can be written at any time at any order using `set_value` and `set_values` methods. This provides a great flexibility while moving the safety responsibility to the caller; hence, the set methods are `unsafe`. |
 //! | Read | Mainly, a write-only collection. Concurrent reading of already pushed elements is through `unsafe` `get` and `iter` methods. The caller is required to avoid race conditions. | A write-and-read collection. Already pushed elements can safely be read through `get` and `iter` methods. | Not supported currently. Due to the flexible but unsafe nature of write operations, it is difficult to provide required safety guarantees as a caller. |
 //! | Ordering of Elements | Since write operations are through adding elements to the end of the pinned vector via `push` and `extend`, two multi-threaded executions of a code that collects elements into the bag might result in the elements being collected in different orders. | Since write operations are through adding elements to the end of the pinned vector via `push` and `extend`, two multi-threaded executions of a code that collects elements into the bag might result in the elements being collected in different orders. | This is the main goal of this collection, allowing to collect elements concurrently and in the correct order. Although this does not seem trivial; it can be achieved almost trivially when `ConcurrentOrderedBag` is used together with a [`ConcurrentIter`](https://crates.io/crates/orx-concurrent-iter). |
-//! | `into_inner` | Once the concurrent collection is completed, the bag can safely be converted to its underlying `PinnedVec<T>` without a cost. | Once the concurrent collection is completed, the bag can safely be converted to its underlying `PinnedVec<Option<T>>` of option-wrapped elements without a cost. | Growing through flexible setters allowing to write to any position, `ConcurrentOrderedBag` has the risk of containing gaps. `into_inner` call provides some useful metrics such as whether the number of elements pushed elements match the  maximum index of the vector; however, it cannot guarantee that the bag is gap-free. The caller is required to take responsibility to unwrap to get the underlying `PinnedVec<T>` through an `unsafe` call. |
+//! | `into_inner` | Once the concurrent collection is completed, the bag can safely be converted to its underlying `PinnedVec<T>`. | Once the concurrent collection is completed, the bag can safely be converted to its underlying `PinnedVec<T>`. | Growing through flexible setters allowing to write to any position, `ConcurrentOrderedBag` has the risk of containing gaps. `into_inner` call provides some useful metrics such as whether the number of elements pushed elements match the  maximum index of the vector; however, it cannot guarantee that the bag is gap-free. The caller is required to take responsibility to unwrap to get the underlying `PinnedVec<T>` through an `unsafe` call. |
 //! |||||
 //!
 //! <div id="section-benchmarks"></div>
@@ -162,9 +161,9 @@
 //!
 //! *You may find the details of the benchmarks at [benches/collect_with_push.rs](https://github.com/orxfun/orx-concurrent-vec/blob/main/benches/collect_with_push.rs) and [benches/collect_with_extend.rs](https://github.com/orxfun/orx-concurrent-vec/blob/main/benches/collect_with_extend.rs).*
 //!
-//! Please see results of benchmarks in the concurrent bag documentation, [here](https://docs.rs/orx-concurrent-bag/latest/orx_concurrent_bag/#section-benchmarks), since no significant impact of the `Option` wrapper is observed and benchmark results are almost identical. In summary:
+//! Please see results of benchmarks in the concurrent bag documentation [here](https://docs.rs/orx-concurrent-bag/latest/orx_concurrent_bag/#section-benchmarks). In summary:
 //!
-//! * Concurrent bag and concurrent vec provide a very high performance collection.
+//! * Concurrent bag and concurrent vec provide a high performance collection.
 //! * Importantly, using `extend` rather than `push` provides further significant performance improvements as it allows to avoid a problem known as *false sharing*. Please see the relevant section [here](https://docs.rs/orx-concurrent-bag/latest/orx_concurrent_bag/#section-performance-notes) for details.
 //!
 //! ## Contributing

--- a/src/mask.rs
+++ b/src/mask.rs
@@ -1,0 +1,127 @@
+use orx_pinned_vec::ConcurrentPinnedVec;
+use orx_split_vec::{ConcurrentSplitVec, Doubling, PinnedVec, SplitVec};
+use std::{
+    fmt::Debug,
+    sync::atomic::{AtomicBool, AtomicUsize, Ordering},
+};
+
+pub struct Mask {
+    is_growing: AtomicBool,
+    safe_cap: AtomicUsize,
+    available: ConcurrentSplitVec<AtomicBool, Doubling>,
+}
+
+impl Debug for Mask {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Mask")
+            .field("is_growing", &self.is_growing)
+            .finish()
+    }
+}
+
+const ORD: Ordering = Ordering::SeqCst;
+
+impl Mask {
+    pub fn new(initial_len: usize) -> Self {
+        let mut data = SplitVec::with_doubling_growth_and_fragments_capacity(32);
+        for _ in 0..initial_len {
+            data.push(AtomicBool::new(true));
+        }
+        let initial_capacity = data.capacity();
+        for _ in initial_len..initial_capacity {
+            data.push(AtomicBool::new(false));
+        }
+        let data = data.into();
+        let safe_len = initial_capacity.into();
+
+        Self {
+            is_growing: AtomicBool::new(false),
+            available: data,
+            safe_cap: safe_len,
+        }
+    }
+
+    #[inline(always)]
+    pub fn is_growing(&self) -> bool {
+        self.is_growing.load(ORD)
+    }
+
+    pub fn len(&self) -> usize {
+        let safe_cap = self.safe_cap.load(ORD);
+        self.available.capacity().min(safe_cap)
+    }
+
+    pub fn taken_until(&self, end_idx_exclusive: usize) {
+        while self.is_growing() {}
+
+        if self.available.capacity() < end_idx_exclusive {
+            self.grow_to(end_idx_exclusive);
+        }
+    }
+
+    pub fn written(&self, begin_idx: usize, end_idx_exclusive: usize) {
+        while self.is_growing() {}
+
+        for i in begin_idx..end_idx_exclusive {
+            let p = unsafe { self.available.get(i) }.expect("exists");
+            p.store(true, ORD);
+        }
+    }
+
+    pub fn is_available(&self, index: usize) -> bool {
+        match unsafe { self.available.get(index) } {
+            Some(p) => p.load(ORD),
+            None => false,
+        }
+    }
+
+    pub fn clear(&mut self) {
+        self.is_growing.store(true, ORD);
+
+        let capacity = self.available.capacity();
+        for i in 0..capacity {
+            let p = unsafe { self.available.get_ptr_mut(i) };
+            unsafe { p.write(AtomicBool::new(false)) };
+        }
+
+        self.is_growing.store(false, ORD);
+    }
+
+    pub fn num_available(&self, len: usize) -> usize {
+        let safe_len = self.safe_cap.load(ORD);
+        let len = len.min(self.available.capacity()).min(safe_len);
+        let mut count = 0;
+        for i in 0..len {
+            let e = unsafe { self.available.get(i) }.expect("exists");
+            if e.load(ORD) {
+                count += 1;
+            }
+        }
+
+        count
+    }
+
+    // locked
+    fn grow_to(&self, new_capacity: usize) {
+        while self
+            .is_growing
+            .compare_exchange_weak(false, true, ORD, ORD)
+            .is_err()
+        {}
+
+        let initial_capacity = self.available.capacity();
+        let new_capacity = self
+            .available
+            .grow_to(new_capacity)
+            .expect("cannot grow further");
+
+        for i in initial_capacity..new_capacity {
+            let p = unsafe { self.available.get_ptr_mut(i) };
+            unsafe { p.write(AtomicBool::new(false)) };
+        }
+
+        self.safe_cap.store(new_capacity, ORD);
+
+        self.is_growing.store(false, ORD);
+    }
+}

--- a/src/new.rs
+++ b/src/new.rs
@@ -1,35 +1,29 @@
 use crate::vec::ConcurrentVec;
-use orx_fixed_vec::{FixedVec, PinnedVec};
-use orx_split_vec::{Doubling, Linear, Recursive, SplitVec};
+use orx_fixed_vec::FixedVec;
+use orx_pinned_vec::IntoConcurrentPinnedVec;
+use orx_split_vec::{Doubling, Linear, SplitVec};
 
-impl<T> Default for ConcurrentVec<T, SplitVec<Option<T>, Doubling>> {
-    /// Creates a new concurrent bag by creating and wrapping up a new [`SplitVec<Option<T>, Doubling>`](https://docs.rs/orx-split-vec/latest/orx_split_vec/struct.Doubling.html) as the underlying storage.
+impl<T> Default for ConcurrentVec<T, SplitVec<T, Doubling>> {
+    /// Creates a new concurrent bag by creating and wrapping up a new [`SplitVec<T, Doubling>`](https://docs.rs/orx-split-vec/latest/orx_split_vec/struct.Doubling.html) as the underlying storage.
     fn default() -> Self {
         Self::with_doubling_growth()
     }
 }
 
-impl<T> ConcurrentVec<T, SplitVec<Option<T>, Doubling>> {
-    /// Creates a new concurrent bag by creating and wrapping up a new [`SplitVec<Option<T>, Doubling>`](https://docs.rs/orx-split-vec/latest/orx_split_vec/struct.Doubling.html) as the underlying storage.
+impl<T> ConcurrentVec<T, SplitVec<T, Doubling>> {
+    /// Creates a new concurrent bag by creating and wrapping up a new [`SplitVec<T, Doubling>`](https://docs.rs/orx-split-vec/latest/orx_split_vec/struct.Doubling.html) as the underlying storage.
     pub fn new() -> Self {
         Self::with_doubling_growth()
     }
 
-    /// Creates a new concurrent bag by creating and wrapping up a new [`SplitVec<Option<T>, Doubling>`](https://docs.rs/orx-split-vec/latest/orx_split_vec/struct.Doubling.html) as the underlying storage.
+    /// Creates a new concurrent bag by creating and wrapping up a new [`SplitVec<T, Doubling>`](https://docs.rs/orx-split-vec/latest/orx_split_vec/struct.Doubling.html) as the underlying storage.
     pub fn with_doubling_growth() -> Self {
         Self::new_from_pinned(SplitVec::with_doubling_growth_and_fragments_capacity(32))
     }
 }
 
-impl<T> ConcurrentVec<T, SplitVec<Option<T>, Recursive>> {
-    /// Creates a new concurrent bag by creating and wrapping up a new [`SplitVec<Option<T>, Recursive>`](https://docs.rs/orx-split-vec/latest/orx_split_vec/struct.Recursive.html) as the underlying storage.
-    pub fn with_recursive_growth() -> Self {
-        Self::new_from_pinned(SplitVec::with_recursive_growth_and_fragments_capacity(32))
-    }
-}
-
-impl<T> ConcurrentVec<T, SplitVec<Option<T>, Linear>> {
-    /// Creates a new concurrent bag by creating and wrapping up a new [`SplitVec<Option<T>, Linear>`](https://docs.rs/orx-split-vec/latest/orx_split_vec/struct.Linear.html) as the underlying storage.
+impl<T> ConcurrentVec<T, SplitVec<T, Linear>> {
+    /// Creates a new concurrent bag by creating and wrapping up a new [`SplitVec<T, Linear>`](https://docs.rs/orx-split-vec/latest/orx_split_vec/struct.Linear.html) as the underlying storage.
     ///
     /// * Each fragment of the split vector will have a capacity of  `2 ^ constant_fragment_capacity_exponent`.
     /// * Further, fragments collection of the split vector will have a capacity of `fragments_capacity` on initialization.
@@ -48,8 +42,8 @@ impl<T> ConcurrentVec<T, SplitVec<Option<T>, Linear>> {
     }
 }
 
-impl<T> ConcurrentVec<T, FixedVec<Option<T>>> {
-    /// Creates a new concurrent bag by creating and wrapping up a new [`FixedVec<Option<T>>`](https://docs.rs/orx-fixed-vec/latest/orx_fixed_vec/) as the underlying storage.
+impl<T> ConcurrentVec<T, FixedVec<T>> {
+    /// Creates a new concurrent bag by creating and wrapping up a new [`FixedVec<T>`](https://docs.rs/orx-fixed-vec/latest/orx_fixed_vec/) as the underlying storage.
     ///
     /// # Safety
     ///
@@ -66,9 +60,9 @@ impl<T> ConcurrentVec<T, FixedVec<Option<T>>> {
 // from
 impl<T, P> From<P> for ConcurrentVec<T, P>
 where
-    P: PinnedVec<Option<T>>,
+    P: IntoConcurrentPinnedVec<T>,
 {
-    /// `ConcurrentVec<Option<T>>` uses any `PinnedVec<T>` implementation as the underlying storage.
+    /// `ConcurrentVec<T>` uses any `PinnedVec<T>` implementation as the underlying storage.
     ///
     /// Therefore, without a cost
     /// * `ConcurrentVec<T>` can be constructed from any `PinnedVec<T>`, and

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,0 +1,6 @@
+pub use crate::vec::ConcurrentVec;
+pub use orx_fixed_vec::FixedVec;
+pub use orx_pinned_vec::{
+    ConcurrentPinnedVec, IntoConcurrentPinnedVec, PinnedVec, PinnedVecGrowthError,
+};
+pub use orx_split_vec::{Doubling, Linear, SplitVec};

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,0 +1,97 @@
+use orx_pinned_concurrent_col::{ConcurrentState, PinnedConcurrentCol, WritePermit};
+use orx_pinned_vec::ConcurrentPinnedVec;
+use std::{
+    cmp::Ordering,
+    sync::atomic::{self, AtomicUsize},
+};
+
+#[derive(Debug)]
+pub struct ConcurrentVecState {
+    len: AtomicUsize,
+    max_written_len: AtomicUsize,
+}
+
+impl ConcurrentState for ConcurrentVecState {
+    #[inline(always)]
+    fn zero_memory(&self) -> bool {
+        false
+    }
+
+    fn new_for_pinned_vec<T, P: orx_fixed_vec::prelude::PinnedVec<T>>(pinned_vec: &P) -> Self {
+        Self {
+            len: pinned_vec.len().into(),
+            max_written_len: pinned_vec.len().into(),
+        }
+    }
+
+    fn new_for_con_pinned_vec<T, P: ConcurrentPinnedVec<T>>(_: &P, len: usize) -> Self {
+        Self {
+            len: len.into(),
+            max_written_len: len.into(),
+        }
+    }
+
+    fn write_permit<T, P, S>(&self, col: &PinnedConcurrentCol<T, P, S>, idx: usize) -> WritePermit
+    where
+        P: ConcurrentPinnedVec<T>,
+        S: ConcurrentState,
+    {
+        let capacity = col.capacity();
+
+        match idx.cmp(&capacity) {
+            Ordering::Less => WritePermit::JustWrite,
+            Ordering::Equal => WritePermit::GrowThenWrite,
+            Ordering::Greater => WritePermit::Spin,
+        }
+    }
+
+    fn write_permit_n_items<T, P, S>(
+        &self,
+        col: &PinnedConcurrentCol<T, P, S>,
+        begin_idx: usize,
+        num_items: usize,
+    ) -> WritePermit
+    where
+        P: ConcurrentPinnedVec<T>,
+        S: ConcurrentState,
+    {
+        let capacity = col.capacity();
+        let last_idx = begin_idx + num_items - 1;
+
+        match (begin_idx.cmp(&capacity), last_idx.cmp(&capacity)) {
+            (_, std::cmp::Ordering::Less) => WritePermit::JustWrite,
+            (std::cmp::Ordering::Greater, _) => WritePermit::Spin,
+            _ => WritePermit::GrowThenWrite,
+        }
+    }
+
+    #[inline(always)]
+    fn release_growth_handle(&self) {}
+
+    #[inline(always)]
+    fn update_after_write(&self, _: usize, end_idx: usize) {
+        self.max_written_len
+            .store(end_idx, atomic::Ordering::SeqCst);
+    }
+
+    fn try_get_no_gap_len(&self) -> Option<usize> {
+        Some(self.len())
+    }
+}
+
+impl ConcurrentVecState {
+    #[inline(always)]
+    pub(crate) fn fetch_increment_len(&self, increment_by: usize) -> usize {
+        self.len.fetch_add(increment_by, atomic::Ordering::SeqCst)
+    }
+
+    #[inline(always)]
+    pub(crate) fn len(&self) -> usize {
+        self.len.load(atomic::Ordering::SeqCst)
+    }
+
+    #[inline(always)]
+    pub(crate) fn max_written_len(&self) -> usize {
+        self.max_written_len.load(atomic::Ordering::SeqCst)
+    }
+}

--- a/tests/concurrent_read.rs
+++ b/tests/concurrent_read.rs
@@ -2,7 +2,7 @@ use orx_concurrent_vec::*;
 use std::time::Duration;
 use test_case::test_case;
 
-const NUM_RERUNS: usize = 4;
+const NUM_RERUNS: usize = 1;
 
 const EXHAUSTIVE_INPUTS: [(usize, usize); 15] = [
     (1, 64),
@@ -22,19 +22,9 @@ const EXHAUSTIVE_INPUTS: [(usize, usize); 15] = [
     (64, 1024),
 ];
 
-const FAST_INPUTS: [(usize, usize); 9] = [
-    (1, 64),
-    (1, 256),
-    (2, 32),
-    (4, 32),
-    (4, 128),
-    (4, 256),
-    (8, 64),
-    (8, 128),
-    (8, 256),
-];
+const FAST_INPUTS: [(usize, usize); 6] = [(1, 64), (1, 256), (2, 32), (4, 32), (4, 128), (8, 256)];
 
-fn run_with_scope<P: PinnedVec<Option<i32>> + Clone + 'static>(
+fn run_with_scope<P: IntoConcurrentPinnedVec<i32> + Clone + 'static>(
     pinned: P,
     num_threads: usize,
     num_items_per_thread: usize,
@@ -44,14 +34,15 @@ fn run_with_scope<P: PinnedVec<Option<i32>> + Clone + 'static>(
         let vec: ConcurrentVec<_, _> = pinned.clone().into();
         let vec_ref = &vec;
         std::thread::scope(|s| {
-            // reader thread
+            // reader thread: continuously reads while other threads write
             s.spawn(move || {
                 let final_len = num_threads * num_items_per_thread;
                 while vec_ref.len_exact() < final_len {
                     #[allow(unused_variables)]
                     let mut sum = 0i64;
 
-                    let len = vec_ref.len();
+                    // it is SAFE to query indices outside the bounds
+                    let len = vec_ref.len() + 100;
                     for i in 0..len {
                         if let Some(value) = vec_ref.get(i) {
                             sum += *value as i64;
@@ -64,7 +55,7 @@ fn run_with_scope<P: PinnedVec<Option<i32>> + Clone + 'static>(
                 }
             });
 
-            // collector threads
+            // writer threads: keeps growing the vec
             for i in 0..num_threads {
                 s.spawn(move || {
                     sleep(do_sleep, i);
@@ -75,11 +66,14 @@ fn run_with_scope<P: PinnedVec<Option<i32>> + Clone + 'static>(
             }
         });
 
-        assert_result(num_threads, num_items_per_thread, &vec);
+        assert_result(num_threads, num_items_per_thread, vec.into_inner());
     }
 }
 
-fn run_test<P: PinnedVec<Option<i32>> + Clone + 'static>(pinned: P, inputs: &[(usize, usize)]) {
+fn run_test<P: IntoConcurrentPinnedVec<i32> + Clone + 'static>(
+    pinned: P,
+    inputs: &[(usize, usize)],
+) {
     for sleep in [false, true] {
         for (num_threads, num_items_per_thread) in inputs {
             run_with_scope(pinned.clone(), *num_threads, *num_items_per_thread, sleep);
@@ -87,23 +81,22 @@ fn run_test<P: PinnedVec<Option<i32>> + Clone + 'static>(pinned: P, inputs: &[(u
     }
 }
 
-#[test_case(FixedVec::new(524288))]
-#[test_case(SplitVec::with_doubling_growth_and_fragments_capacity(32))]
-#[test_case(SplitVec::with_recursive_growth_and_fragments_capacity(32))]
-#[test_case(SplitVec::with_linear_growth_and_fragments_capacity(6, 8192))]
-#[test_case(SplitVec::with_linear_growth_and_fragments_capacity(10, 512))]
-#[test_case(SplitVec::with_linear_growth_and_fragments_capacity(14, 32))]
-fn exhaustive<P: PinnedVec<Option<i32>> + Clone + 'static>(pinned: P) {
+// #[test_case(FixedVec::new(524288))]
+// #[test_case(SplitVec::with_doubling_growth_and_fragments_capacity(32))]
+// #[test_case(SplitVec::with_linear_growth_and_fragments_capacity(6, 8192))]
+// #[test_case(SplitVec::with_linear_growth_and_fragments_capacity(10, 512))]
+// #[test_case(SplitVec::with_linear_growth_and_fragments_capacity(14, 32))]
+#[allow(dead_code)]
+fn concurrent_read_exhaustive<P: IntoConcurrentPinnedVec<i32> + Clone + 'static>(pinned: P) {
     run_test(pinned, &EXHAUSTIVE_INPUTS)
 }
 
 #[test_case(FixedVec::new(3000))]
 #[test_case(SplitVec::with_doubling_growth_and_fragments_capacity(32))]
-#[test_case(SplitVec::with_recursive_growth_and_fragments_capacity(32))]
 #[test_case(SplitVec::with_linear_growth_and_fragments_capacity(6, 40))]
 #[test_case(SplitVec::with_linear_growth_and_fragments_capacity(10, 10))]
 #[test_case(SplitVec::with_linear_growth_and_fragments_capacity(14, 10))]
-fn fast<P: PinnedVec<Option<i32>> + Clone + 'static>(pinned: P) {
+fn concurrent_read_fast<P: IntoConcurrentPinnedVec<i32> + Clone + 'static>(pinned: P) {
     run_test(pinned, &FAST_INPUTS)
 }
 
@@ -116,12 +109,12 @@ fn expected_result(num_threads: usize, num_items_per_thread: usize) -> Vec<i32> 
     expected
 }
 
-fn assert_result<P: PinnedVec<Option<i32>>>(
+fn assert_result<P: IntoConcurrentPinnedVec<i32>>(
     num_threads: usize,
     num_items_per_thread: usize,
-    bag: &ConcurrentVec<i32, P>,
+    vec_from_bag: P,
 ) {
-    let mut vec_from_bag: Vec<_> = bag.iter().copied().collect();
+    let mut vec_from_bag: Vec<_> = vec_from_bag.iter().copied().collect();
     vec_from_bag.sort();
 
     let expected = expected_result(num_threads, num_items_per_thread);

--- a/tests/drop.rs
+++ b/tests/drop.rs
@@ -5,12 +5,11 @@ use test_case::test_matrix;
     [
         FixedVec::new(100000),
         SplitVec::with_doubling_growth_and_fragments_capacity(32),
-        SplitVec::with_recursive_growth_and_fragments_capacity(32),
         SplitVec::with_linear_growth_and_fragments_capacity(10, 64),
     ],
-    [124, 348, 1024, 2587, 42578]
+    [124, 348, 1024, 2587]
 )]
-fn dropped_as_vec<P: PinnedVec<Option<String>>>(pinned_vec: P, len: usize) {
+fn dropped_as_vec<P: IntoConcurrentPinnedVec<String>>(pinned_vec: P, len: usize) {
     let num_threads = 4;
     let num_items_per_thread = len / num_threads;
 
@@ -23,12 +22,11 @@ fn dropped_as_vec<P: PinnedVec<Option<String>>>(pinned_vec: P, len: usize) {
     [
         FixedVec::new(100000),
         SplitVec::with_doubling_growth_and_fragments_capacity(32),
-        SplitVec::with_recursive_growth_and_fragments_capacity(32),
         SplitVec::with_linear_growth_and_fragments_capacity(10, 64),
     ],
-    [124, 348, 1024, 2587, 42578]
+    [124, 348, 1024, 2587]
 )]
-fn dropped_after_into_inner<P: PinnedVec<Option<String>>>(pinned_vec: P, len: usize) {
+fn dropped_after_into_inner<P: IntoConcurrentPinnedVec<String>>(pinned_vec: P, len: usize) {
     let num_threads = 4;
     let num_items_per_thread = len / num_threads;
 
@@ -38,7 +36,10 @@ fn dropped_after_into_inner<P: PinnedVec<Option<String>>>(pinned_vec: P, len: us
     assert_eq!(inner.len(), num_threads * num_items_per_thread);
 }
 
-fn fill_vec<P: PinnedVec<Option<String>>>(pinned_vec: P, len: usize) -> ConcurrentVec<String, P> {
+fn fill_vec<P: IntoConcurrentPinnedVec<String>>(
+    pinned_vec: P,
+    len: usize,
+) -> ConcurrentVec<String, P> {
     let num_threads = 4;
     let num_items_per_thread = len / num_threads;
 

--- a/tests/extend.rs
+++ b/tests/extend.rs
@@ -1,11 +1,11 @@
 use orx_concurrent_vec::*;
 use orx_fixed_vec::FixedVec;
-use orx_pinned_vec::PinnedVec;
+use orx_pinned_vec::IntoConcurrentPinnedVec;
 use orx_split_vec::SplitVec;
-use std::{sync::Arc, thread, time::Duration};
+use std::time::Duration;
 use test_case::test_case;
 
-const NUM_RERUNS: usize = 4;
+const NUM_RERUNS: usize = 1;
 
 const EXHAUSTIVE_INPUTS: [(usize, usize); 15] = [
     (1, 64),
@@ -25,47 +25,9 @@ const EXHAUSTIVE_INPUTS: [(usize, usize); 15] = [
     (64, 1024),
 ];
 
-const FAST_INPUTS: [(usize, usize); 9] = [
-    (1, 64),
-    (1, 256),
-    (2, 32),
-    (4, 32),
-    (4, 128),
-    (4, 256),
-    (8, 64),
-    (8, 128),
-    (8, 256),
-];
+const FAST_INPUTS: [(usize, usize); 6] = [(1, 64), (1, 256), (2, 32), (4, 32), (4, 128), (8, 256)];
 
-fn run_with_arc<P: PinnedVec<Option<i32>> + Clone + 'static>(
-    pinned: P,
-    num_threads: usize,
-    num_items_per_thread: usize,
-    do_sleep: bool,
-) {
-    for _ in 0..NUM_RERUNS {
-        let bag: ConcurrentVec<_, _> = pinned.clone().into();
-        let bag = Arc::new(bag);
-        let mut thread_vec: Vec<thread::JoinHandle<()>> = Vec::new();
-
-        for i in 0..num_threads {
-            let bag = bag.clone();
-            thread_vec.push(thread::spawn(move || {
-                sleep(do_sleep, i);
-                let into_iter = (0..num_items_per_thread).map(|j| (i * 100000 + j) as i32);
-                bag.extend(into_iter);
-            }));
-        }
-
-        for handle in thread_vec {
-            handle.join().unwrap();
-        }
-
-        assert_result(num_threads, num_items_per_thread, &bag);
-    }
-}
-
-fn run_with_scope<P: PinnedVec<Option<i32>> + Clone + 'static>(
+fn run_with_scope<P: IntoConcurrentPinnedVec<i32> + Clone + 'static>(
     pinned: P,
     num_threads: usize,
     num_items_per_thread: usize,
@@ -84,36 +46,37 @@ fn run_with_scope<P: PinnedVec<Option<i32>> + Clone + 'static>(
             }
         });
 
-        assert_result(num_threads, num_items_per_thread, &bag);
+        assert_result(num_threads, num_items_per_thread, bag.into_inner());
     }
 }
 
-fn run_test<P: PinnedVec<Option<i32>> + Clone + 'static>(pinned: P, inputs: &[(usize, usize)]) {
+fn run_test<P: IntoConcurrentPinnedVec<i32> + Clone + 'static>(
+    pinned: P,
+    inputs: &[(usize, usize)],
+) {
     for sleep in [false, true] {
         for (num_threads, num_items_per_thread) in inputs.iter() {
-            run_with_arc(pinned.clone(), *num_threads, *num_items_per_thread, sleep);
             run_with_scope(pinned.clone(), *num_threads, *num_items_per_thread, sleep);
         }
     }
 }
 
-#[test_case(FixedVec::new(524288))]
-#[test_case(SplitVec::with_doubling_growth_and_fragments_capacity(32))]
-#[test_case(SplitVec::with_recursive_growth_and_fragments_capacity(32))]
-#[test_case(SplitVec::with_linear_growth_and_fragments_capacity(6, 8192))]
-#[test_case(SplitVec::with_linear_growth_and_fragments_capacity(10, 512))]
-#[test_case(SplitVec::with_linear_growth_and_fragments_capacity(14, 32))]
-fn exhaustive<P: PinnedVec<Option<i32>> + Clone + 'static>(pinned: P) {
+// #[test_case(FixedVec::new(524288))]
+// #[test_case(SplitVec::with_doubling_growth_and_fragments_capacity(32))]
+// #[test_case(SplitVec::with_linear_growth_and_fragments_capacity(6, 8192))]
+// #[test_case(SplitVec::with_linear_growth_and_fragments_capacity(10, 512))]
+// #[test_case(SplitVec::with_linear_growth_and_fragments_capacity(14, 32))]
+#[allow(dead_code)]
+fn push_exhaustive<P: IntoConcurrentPinnedVec<i32> + Clone + 'static>(pinned: P) {
     run_test(pinned, &EXHAUSTIVE_INPUTS)
 }
 
 #[test_case(FixedVec::new(3000))]
 #[test_case(SplitVec::with_doubling_growth_and_fragments_capacity(32))]
-#[test_case(SplitVec::with_recursive_growth_and_fragments_capacity(32))]
 #[test_case(SplitVec::with_linear_growth_and_fragments_capacity(6, 40))]
 #[test_case(SplitVec::with_linear_growth_and_fragments_capacity(10, 10))]
 #[test_case(SplitVec::with_linear_growth_and_fragments_capacity(14, 10))]
-fn fast<P: PinnedVec<Option<i32>> + Clone + 'static>(pinned: P) {
+fn push_fast<P: IntoConcurrentPinnedVec<i32> + Clone + 'static>(pinned: P) {
     run_test(pinned, &FAST_INPUTS)
 }
 
@@ -126,12 +89,12 @@ fn expected_result(num_threads: usize, num_items_per_thread: usize) -> Vec<i32> 
     expected
 }
 
-fn assert_result<P: PinnedVec<Option<i32>>>(
+fn assert_result<P: IntoConcurrentPinnedVec<i32>>(
     num_threads: usize,
     num_items_per_thread: usize,
-    bag: &ConcurrentVec<i32, P>,
+    vec_from_bag: P,
 ) {
-    let mut vec_from_bag: Vec<_> = bag.iter().copied().collect();
+    let mut vec_from_bag: Vec<_> = vec_from_bag.iter().copied().collect();
     vec_from_bag.sort();
 
     let expected = expected_result(num_threads, num_items_per_thread);

--- a/tests/get_iter_mut.rs
+++ b/tests/get_iter_mut.rs
@@ -1,7 +1,7 @@
 use orx_concurrent_vec::*;
 use test_case::test_case;
 
-fn run_test<P: PinnedVec<Option<String>> + Clone + 'static>(pinned: P) {
+fn run_test<P: IntoConcurrentPinnedVec<String> + Clone + 'static>(pinned: P) {
     let mut vec: ConcurrentVec<_, _> = pinned.into();
     for i in 0..2484 {
         vec.push(i.to_string());
@@ -28,10 +28,9 @@ fn run_test<P: PinnedVec<Option<String>> + Clone + 'static>(pinned: P) {
 
 #[test_case(FixedVec::new(2484))]
 #[test_case(SplitVec::with_doubling_growth_and_fragments_capacity(32))]
-#[test_case(SplitVec::with_recursive_growth_and_fragments_capacity(32))]
 #[test_case(SplitVec::with_linear_growth_and_fragments_capacity(6, 8192))]
 #[test_case(SplitVec::with_linear_growth_and_fragments_capacity(10, 512))]
 #[test_case(SplitVec::with_linear_growth_and_fragments_capacity(14, 32))]
-fn get_iter_mut<P: PinnedVec<Option<String>> + Clone + 'static>(pinned: P) {
+fn get_iter_mut<P: IntoConcurrentPinnedVec<String> + Clone + 'static>(pinned: P) {
     run_test(pinned)
 }

--- a/tests/new.rs
+++ b/tests/new.rs
@@ -2,9 +2,7 @@ use orx_concurrent_vec::*;
 
 #[test]
 fn new_len_empty_clear() {
-    fn test<P: PinnedVec<Option<char>>>(bag: ConcurrentVec<char, P>) {
-        assert!(!bag.zeroes_memory_on_allocation());
-
+    fn test<P: IntoConcurrentPinnedVec<char>>(bag: ConcurrentVec<char, P>) {
         let mut bag = bag;
 
         assert!(bag.is_empty());

--- a/tests/pinned_concurrent_col.rs
+++ b/tests/pinned_concurrent_col.rs
@@ -1,16 +1,10 @@
 use orx_concurrent_vec::*;
 use std::time::Duration;
+use test_case::test_matrix;
 
 #[test]
 fn capacity() {
-    let mut split: SplitVec<_, Doubling> = (0..4).map(Some).collect();
-    split.concurrent_reserve(5).expect("is-ok");
-    let bag: ConcurrentVec<_, _> = split.into();
-    assert_eq!(bag.capacity(), 4);
-    bag.push(42);
-    assert_eq!(bag.capacity(), 12);
-
-    let mut split: SplitVec<_, Recursive> = (0..4).map(Some).collect();
+    let mut split: SplitVec<_, Doubling> = (0..4).collect();
     split.concurrent_reserve(5).expect("is-ok");
     let bag: ConcurrentVec<_, _> = split.into();
     assert_eq!(bag.capacity(), 4);
@@ -18,7 +12,7 @@ fn capacity() {
     assert_eq!(bag.capacity(), 12);
 
     let mut split: SplitVec<_, Linear> = SplitVec::with_linear_growth(2);
-    split.extend_from_slice(&[0, 1, 2, 3].map(Some));
+    split.extend_from_slice(&[0, 1, 2, 3]);
     split.concurrent_reserve(5).expect("is-ok");
     let bag: ConcurrentVec<_, _> = split.into();
     assert_eq!(bag.capacity(), 4);
@@ -26,33 +20,41 @@ fn capacity() {
     assert_eq!(bag.capacity(), 8);
 
     let mut fixed: FixedVec<_> = FixedVec::new(5);
-    fixed.extend_from_slice(&[0, 1, 2, 3].map(Some));
+    fixed.extend_from_slice(&[0, 1, 2, 3]);
     let bag: ConcurrentVec<_, _> = fixed.into();
     assert_eq!(bag.capacity(), 5);
     bag.push(42);
     assert_eq!(bag.capacity(), 5);
 }
 
-#[test]
+#[test_matrix([
+    FixedVec::new(5),
+    SplitVec::with_doubling_growth_and_fragments_capacity(1),
+    SplitVec::with_linear_growth_and_fragments_capacity(2, 1)
+])]
 #[should_panic]
-fn exceeding_fixed_capacity_panics() {
-    let mut fixed: FixedVec<_> = FixedVec::new(5);
-    fixed.extend_from_slice(&[0, 1, 2, 3].map(Some));
-    let bag: ConcurrentVec<_, _> = fixed.into();
+fn exceeding_fixed_capacity_panics<P: IntoConcurrentPinnedVec<usize>>(mut pinned_vec: P) {
+    pinned_vec.clear();
+    pinned_vec.extend_from_slice(&[0, 1, 2, 3]);
+    let bag: ConcurrentVec<_, _> = pinned_vec.into();
     assert_eq!(bag.capacity(), 5);
     bag.push(42);
     bag.push(7);
 }
 
-#[test]
+#[test_matrix([
+    FixedVec::new(10),
+    SplitVec::with_doubling_growth_and_fragments_capacity(2),
+    SplitVec::with_linear_growth_and_fragments_capacity(2, 3)
+])]
 #[should_panic]
-fn exceeding_fixed_capacity_panics_concurrently() {
-    let bag = ConcurrentVec::with_fixed_capacity(10);
+fn exceeding_fixed_capacity_panics_concurrently<P: IntoConcurrentPinnedVec<usize>>(pinned_vec: P) {
+    let bag: ConcurrentVec<_, _> = pinned_vec.into();
     let bag_ref = &bag;
     std::thread::scope(|s| {
         for _ in 0..4 {
             s.spawn(move || {
-                for _ in 0..3 {
+                for _ in 0..4 {
                     // in total there will be 4*3 = 12 pushes
                     bag_ref.push(42);
                 }
@@ -61,18 +63,30 @@ fn exceeding_fixed_capacity_panics_concurrently() {
     });
 }
 
-#[test]
-fn get() {
+#[test_matrix([
+    FixedVec::new(100),
+    SplitVec::with_doubling_growth_and_fragments_capacity(16),
+    SplitVec::with_linear_growth_and_fragments_capacity(10, 16)
+], [
+    FixedVec::new(100),
+    SplitVec::with_doubling_growth_and_fragments_capacity(16),
+    SplitVec::with_linear_growth_and_fragments_capacity(10, 16)
+])]
+fn concurrent_get_and_iter<P, Q>(pinned_i32: P, pinned_f32: Q)
+where
+    P: IntoConcurrentPinnedVec<i32> + Clone,
+    Q: IntoConcurrentPinnedVec<f32>,
+{
     // record measurements in (assume) random intervals
-    let measurements = ConcurrentVec::<i32>::new();
+    let measurements: ConcurrentVec<_, _> = pinned_i32.clone().into();
     let rf_measurements = &measurements;
 
     // collect sum of measurements every 50 milliseconds
-    let sums = ConcurrentVec::new();
+    let sums: ConcurrentVec<_, _> = pinned_i32.into();
     let rf_sums = &sums;
 
     // collect average of measurements every 50 milliseconds
-    let averages = ConcurrentVec::new();
+    let averages: ConcurrentVec<_, _> = pinned_f32.into();
     let rf_averages = &averages;
 
     std::thread::scope(|s| {
@@ -96,17 +110,16 @@ fn get() {
 
         s.spawn(move || {
             for _ in 0..10 {
-                let count = rf_measurements.len();
-                if count == 0 {
-                    rf_averages.push(0.0);
-                } else {
-                    let mut sum = 0;
-                    for i in 0..rf_measurements.len() {
-                        sum += rf_measurements.get(i).copied().unwrap_or(0);
-                    }
-                    let average = sum as f32 / count as f32;
-                    rf_averages.push(average);
+                // better to have count & add as an atomic reduction for correctness
+                // calling .len() and .iter().sum() separately might possibly give a false average
+                fn count_and_add(len_and_sum: (usize, i32), x: &i32) -> (usize, i32) {
+                    (len_and_sum.0 + 1, len_and_sum.1 + x)
                 }
+
+                let (len, sum) = rf_measurements.iter().fold((0, 0), count_and_add);
+                let average = sum as f32 / len as f32;
+                rf_averages.push(average);
+
                 std::thread::sleep(Duration::from_millis(50));
             }
         });
@@ -117,27 +130,88 @@ fn get() {
     assert_eq!(averages.len(), 10);
 }
 
-#[test]
-fn iter() {
-    let mut bag = ConcurrentVec::new();
+#[test_matrix([
+    FixedVec::new(10),
+    SplitVec::with_doubling_growth_and_fragments_capacity(2),
+    SplitVec::with_linear_growth_and_fragments_capacity(2, 3)
+])]
+fn get_iter<P: IntoConcurrentPinnedVec<char>>(pinned_vec: P) {
+    let mut bag: ConcurrentVec<_, _> = pinned_vec.into();
 
     assert_eq!(0, bag.iter().count());
+    assert_eq!(None, bag.get(0));
 
     bag.push('a');
 
     assert_eq!(vec!['a'], bag.iter().copied().collect::<Vec<_>>());
+    assert_eq!(Some(&'a'), bag.get(0));
+    assert_eq!(None, bag.get(1));
 
     bag.push('b');
     bag.push('c');
     bag.push('d');
+    bag.push('e');
 
     assert_eq!(
-        vec!['a', 'b', 'c', 'd'],
+        vec!['a', 'b', 'c', 'd', 'e'],
         bag.iter().copied().collect::<Vec<_>>()
     );
+    assert_eq!(Some(&'d'), bag.get(3));
+    assert_eq!(None, bag.get(5));
 
     bag.clear();
     assert_eq!(0, bag.iter().count());
+}
+
+#[test_matrix([
+    FixedVec::new(10),
+    SplitVec::with_doubling_growth_and_fragments_capacity(2),
+    SplitVec::with_linear_growth_and_fragments_capacity(2, 3)
+])]
+fn get_mut<P: IntoConcurrentPinnedVec<String>>(pinned_vec: P) {
+    let mut bag: ConcurrentVec<_, _> = pinned_vec.into();
+
+    assert_eq!(None, bag.get_mut(0));
+
+    bag.push("a".to_string());
+    bag.push("b".to_string());
+    bag.push("c".to_string());
+    bag.push("d".to_string());
+    bag.push("e".to_string());
+
+    assert_eq!(None, bag.get_mut(5));
+    assert_eq!(Some("c"), bag.get_mut(2).map(|x| x.as_str()));
+    *bag.get_mut(2).unwrap() = "c!".to_string();
+
+    let vec: Vec<_> = bag.iter().collect();
+    assert_eq!(vec, ["a", "b", "c!", "d", "e"]);
+}
+
+#[test_matrix([
+    FixedVec::new(10),
+    SplitVec::with_doubling_growth_and_fragments_capacity(2),
+    SplitVec::with_linear_growth_and_fragments_capacity(2, 3),
+])]
+fn iter_mut<P: IntoConcurrentPinnedVec<String>>(pinned_vec: P) {
+    let mut bag: ConcurrentVec<_, _> = pinned_vec.into();
+
+    assert_eq!(0, bag.iter_mut().count());
+
+    bag.push("a".to_string());
+
+    assert_eq!(Some("a"), bag.iter_mut().next().map(|x| x.as_str()));
+
+    bag.push("b".to_string());
+    bag.push("c".to_string());
+    bag.push("d".to_string());
+    bag.push("e".to_string());
+
+    for x in bag.iter_mut().filter(|x| x.as_str() != "c") {
+        *x = format!("{}!", x);
+    }
+
+    let vec: Vec<_> = bag.iter().collect();
+    assert_eq!(vec, ["a!", "b!", "c", "d!", "e!"]);
 }
 
 #[test]
@@ -157,20 +231,19 @@ fn reserve_maximum_capacity() {
     assert_eq!(bag.maximum_capacity(), 2usize.pow(10) * 20); // it can concurrently allocate 19 more
 
     // SplitVec<_, Linear> -> reserve_maximum_capacity
-    let result = bag.reserve_maximum_capacity(2usize.pow(10) * 30);
-    assert!(result.is_ok());
-    assert!(result.expect("is-ok") >= 2usize.pow(10) * 30);
+    let new_max_capacity = bag.reserve_maximum_capacity(2usize.pow(10) * 30);
+    assert!(new_max_capacity >= 2usize.pow(10) * 30);
 
     // actually no new allocation yet; precisely additional memory for 10 pairs of pointers is used
     assert_eq!(bag.capacity(), 2usize.pow(10)); // first fragment capacity
 
     assert!(bag.maximum_capacity() >= 2usize.pow(10) * 30); // now it can safely reach 2^10 * 30
 
-    // FixedVec<_>: pre-allocated, exact and strict
+    // FixedVec<_>
     let mut bag: ConcurrentVec<char, _> = ConcurrentVec::with_fixed_capacity(42);
     assert_eq!(bag.capacity(), 42);
     assert_eq!(bag.maximum_capacity(), 42);
 
-    let result = bag.reserve_maximum_capacity(43);
-    assert!(result.is_err());
+    let new_max_capacity = bag.reserve_maximum_capacity(1024);
+    assert!(new_max_capacity >= 1024);
 }

--- a/tests/push_out_of_capacity.rs
+++ b/tests/push_out_of_capacity.rs
@@ -1,10 +1,9 @@
 use orx_concurrent_vec::*;
 use orx_fixed_vec::FixedVec;
-use orx_pinned_vec::PinnedVec;
 use orx_split_vec::SplitVec;
 use std::time::Duration;
 
-fn run_with_scope<P: PinnedVec<Option<i32>> + Clone + 'static>(
+fn run_with_scope<P: IntoConcurrentPinnedVec<i32> + Clone + 'static>(
     pinned: P,
     num_threads: usize,
     num_items_per_thread: usize,
@@ -37,14 +36,6 @@ fn out_of_capacity_linear() {
 fn out_of_capacity_doubling() {
     let (num_threads, num_items_per_thread) = (5, 15);
     let pinned = SplitVec::with_doubling_growth_and_fragments_capacity(4); // up to 4 + 8 + 16 + 32 = 60
-    run_with_scope(pinned, num_threads, num_items_per_thread, true);
-}
-
-#[test]
-#[should_panic]
-fn out_of_capacity_recursive() {
-    let (num_threads, num_items_per_thread) = (5, 15);
-    let pinned = SplitVec::with_recursive_growth_and_fragments_capacity(4); // up to 4 + 8 + 16 + 32 = 60
     run_with_scope(pinned, num_threads, num_items_per_thread, true);
 }
 


### PR DESCRIPTION
# Concurrency Model Revision

With this major refactoring, safety issues are fixed to achieve a miri safe version for all the tests defined in this crate.

The refactoring consists of two main parts: downstream changes in pinned vector's concurrency support and replacing Option<T> with T and AtomicBool vector.

## PinnedVec Support for Concurrency

In version 2, PinnedVec grew with new methods to support concurrent data structures. However, this caused problems since these exposed methods were often unsafe, and further, they were not directly useful for the pinned vector consumers except for concurrent data structures wrapping a pinned vector. Furthermore, they are alien to a regular vector interface that we are used to using.

In version 3, a second trait called `ConcurrentPinnedVec` is defined. All useful methods related with concurrent programming are moved to this trait. This trait has an associated type defining the underlying pinned vector type. It can be turned into the pinned vector.

Finally, `IntoConcurrentPinnedVec` trait is defined. A pinned vector implementing this trait can be turned into a `ConcurrentPinnedVec`. As explained above, it can be converted back to the pinned vector.

In this release `ConcurrentVe` wraps a `ConcurrentPinnedVec` rather than a `PinnedVec`.

## Concurrency State

The main goal of ConcurrentVec is to enable safe reading while allowing it to efficiently grow. In version 1, it was attempted to achieve this through wrapping the elements by an Option. Although this turned out to pass exhaustive tests, it had two problems. Firstly, it is not best to have a vector of Option<T> rather than that of T's, since the concurrent collection allows to transform `into_inner`. In version 2, underlying concurrent pinned vector stores elements as T, and hence, we can directly get the vector of T's. Secondly, version 1 failed miri tests for the tests where we read & grow concurrently. Having a parallel concurrent vector of atomic bools, the race condition is eliminated in version 2.