### PR TITLE
upgraded-pinned-vector-deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-concurrent-vec"
-version = "3.0.2"
+version = "3.1.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "A thread-safe, efficient and lock-free vector allowing concurrent grow, read and update operations."
@@ -11,10 +11,10 @@ categories = ["data-structures", "concurrency", "rust-patterns", "no-std"]
 
 [dependencies]
 orx-pseudo-default = { version = "1.4", default-features = false }
-orx-pinned-vec = "3.10"
-orx-fixed-vec = "3.10"
-orx-split-vec = "3.10"
-orx-pinned-concurrent-col = "2.8"
+orx-pinned-vec = "3.11"
+orx-fixed-vec = "3.11"
+orx-split-vec = "3.11"
+orx-pinned-concurrent-col = "2.9"
 orx-concurrent-option = "1.3"
 
 [dev-dependencies]

--- a/src/common_traits/debug.rs
+++ b/src/common_traits/debug.rs
@@ -18,7 +18,7 @@ where
     }
 }
 
-impl<'a, T, P> Debug for ConcurrentSlice<'a, T, P>
+impl<T, P> Debug for ConcurrentSlice<'_, T, P>
 where
     P: IntoConcurrentPinnedVec<ConcurrentElement<T>>,
     T: Debug,

--- a/src/common_traits/eq.rs
+++ b/src/common_traits/eq.rs
@@ -22,8 +22,8 @@ impl<T: PartialEq> PartialEq for ConcurrentVec<T> {
     }
 }
 
-impl<'a, T: PartialEq> PartialEq<ConcurrentSlice<'a, T>> for ConcurrentVec<T> {
-    fn eq(&self, other: &ConcurrentSlice<'a, T>) -> bool {
+impl<T: PartialEq> PartialEq<ConcurrentSlice<'_, T>> for ConcurrentVec<T> {
+    fn eq(&self, other: &ConcurrentSlice<'_, T>) -> bool {
         eq_elem_iters(self.iter(), other.iter())
     }
 }
@@ -42,25 +42,25 @@ impl<const N: usize, T: PartialEq> PartialEq<[T; N]> for ConcurrentVec<T> {
 
 // slice
 
-impl<'a, T: PartialEq> PartialEq for ConcurrentSlice<'a, T> {
+impl<T: PartialEq> PartialEq for ConcurrentSlice<'_, T> {
     fn eq(&self, other: &Self) -> bool {
         eq_elem_iters(self.iter(), other.iter())
     }
 }
 
-impl<'a, T: PartialEq> PartialEq<ConcurrentVec<T>> for ConcurrentSlice<'a, T> {
+impl<T: PartialEq> PartialEq<ConcurrentVec<T>> for ConcurrentSlice<'_, T> {
     fn eq(&self, other: &ConcurrentVec<T>) -> bool {
         eq_elem_iters(self.iter(), other.iter())
     }
 }
 
-impl<'a, T: PartialEq> PartialEq<[T]> for ConcurrentSlice<'a, T> {
+impl<T: PartialEq> PartialEq<[T]> for ConcurrentSlice<'_, T> {
     fn eq(&self, other: &[T]) -> bool {
         eq_elem_iter_to_iter(self.iter(), other.iter())
     }
 }
 
-impl<'a, const N: usize, T: PartialEq> PartialEq<[T; N]> for ConcurrentSlice<'a, T> {
+impl<const N: usize, T: PartialEq> PartialEq<[T; N]> for ConcurrentSlice<'_, T> {
     fn eq(&self, other: &[T; N]) -> bool {
         eq_elem_iter_to_iter(self.iter(), other.iter())
     }

--- a/src/common_traits/index.rs
+++ b/src/common_traits/index.rs
@@ -24,7 +24,7 @@ where
 
 // ConcurrentSlice
 
-impl<'a, P, T> Index<usize> for ConcurrentSlice<'a, T, P>
+impl<P, T> Index<usize> for ConcurrentSlice<'_, T, P>
 where
     P: IntoConcurrentPinnedVec<ConcurrentElement<T>>,
 {

--- a/src/concurrent_slice/mut_elem.rs
+++ b/src/concurrent_slice/mut_elem.rs
@@ -2,7 +2,7 @@ use super::ConcurrentSlice;
 use crate::elem::ConcurrentElement;
 use orx_fixed_vec::IntoConcurrentPinnedVec;
 
-impl<'a, T, P> ConcurrentSlice<'a, T, P>
+impl<T, P> ConcurrentSlice<'_, T, P>
 where
     P: IntoConcurrentPinnedVec<ConcurrentElement<T>>,
 {

--- a/src/concurrent_slice/partial_eq.rs
+++ b/src/concurrent_slice/partial_eq.rs
@@ -2,7 +2,7 @@ use super::ConcurrentSlice;
 use crate::elem::ConcurrentElement;
 use orx_fixed_vec::IntoConcurrentPinnedVec;
 
-impl<'a, T, P> ConcurrentSlice<'a, T, P>
+impl<T, P> ConcurrentSlice<'_, T, P>
 where
     P: IntoConcurrentPinnedVec<ConcurrentElement<T>>,
     T: PartialEq,

--- a/src/concurrent_slice/to_vec.rs
+++ b/src/concurrent_slice/to_vec.rs
@@ -3,7 +3,7 @@ use crate::elem::ConcurrentElement;
 use alloc::vec::Vec;
 use orx_fixed_vec::IntoConcurrentPinnedVec;
 
-impl<'a, T, P> ConcurrentSlice<'a, T, P>
+impl<T, P> ConcurrentSlice<'_, T, P>
 where
     P: IntoConcurrentPinnedVec<ConcurrentElement<T>>,
 {

--- a/src/concurrent_slice/unsafe_api.rs
+++ b/src/concurrent_slice/unsafe_api.rs
@@ -3,7 +3,7 @@ use crate::ConcurrentElement;
 use core::sync::atomic::Ordering;
 use orx_pinned_vec::IntoConcurrentPinnedVec;
 
-impl<'a, T, P> ConcurrentSlice<'a, T, P>
+impl<T, P> ConcurrentSlice<'_, T, P>
 where
     P: IntoConcurrentPinnedVec<ConcurrentElement<T>>,
 {


### PR DESCRIPTION
* PinnedVec dependencies are upgraded to the latest.
* New clippy warnings are fixed.