### PR TITLE
Serde feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,5 +36,5 @@ name = "collect_with_extend"
 harness = false
 
 [features]
-default = ["serde"]
+default = []
 serde = ["dep:serde"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-concurrent-vec"
-version = "3.1.2"
+version = "3.2.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "A thread-safe, efficient and lock-free vector allowing concurrent grow, read and update operations."
@@ -16,17 +16,25 @@ orx-fixed-vec = "3.11"
 orx-split-vec = "3.11"
 orx-pinned-concurrent-col = "2.9"
 orx-concurrent-option = "1.3"
+serde = { version = "1.0.217", optional = true, default-features = false }
 
 [dev-dependencies]
+append-only-vec = "0.1.5"
+boxcar = "0.2.5"
 clap = { version = "4.5.17", features = ["derive"] }
 criterion = "0.5.1"
 rand = "0.8"
 rand_chacha = "0.3"
 rayon = "1.9.0"
+serde_json = { version = "1.0.135", default-features = false, features = [
+    "std",
+] }
 test-case = "3.3.1"
-append-only-vec = "0.1.5"
-boxcar = "0.2.5"
 
 [[bench]]
 name = "collect_with_extend"
 harness = false
+
+[features]
+default = ["serde"]
+serde = ["dep:serde"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-concurrent-vec"
-version = "3.1.1"
+version = "3.1.2"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "A thread-safe, efficient and lock-free vector allowing concurrent grow, read and update operations."

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Currently, `ConcurrentVec` cannot change positions of existing elements concurre
 
 We can replace `ConcurrentVec<T>` with `Arc<Mutex<Vec<T>>>` which would provide us with entire functionality of the standard vector. However, especially in performance critical scenarios, locking an entire vector for each access might not be a good strategy.
 
-> *A drop-in replacement for `Arc<Mutex<Vec<T>>>` in shared owner cases would have been `Arc<ConcurrentVec<T>>`, while in many scenarios `&ConcurrentVec<T>` would suffice to share the mutable state. However, it is important to note the difference in clone behavior; unlike `Arc::clone`, ConcurrentVec::clone()` clones the underlying data.*
+> *A drop-in replacement for `Arc<Mutex<Vec<T>>>` in shared owner cases would have been `Arc<ConcurrentVec<T>>`, while in many scenarios `&ConcurrentVec<T>` would suffice to share the mutable state. However, it is important to note the difference in clone behavior; unlike `Arc::clone`, `ConcurrentVec::clone()` clones the underlying data.*
 
 The [updater_reader](https://github.com/orxfun/orx-concurrent-vec/blob/main/examples/updater_reader.rs) example aims to demonstrate the impact of locking in such a scenario. In the example, we create and fill a vector and share it with two types of actors, updaters & readers:
 * We spawn `num_updaters` threads, each of which continuously draws an index, and updates the element at the given index.

--- a/README.md
+++ b/README.md
@@ -178,6 +178,11 @@ The document [ConcurrentGrowthBenchmark.md](https://github.com/orxfun/orx-concur
 
 Of course, not all scenarios allow to extend in batches. However, whenever possible, it is preferable due to potential significant performance improvements.
 
+## Opt-in Features
+
+* **std**: This is a no-std crate by default, and hence, "std" feature needs to be included when necessary.
+* **serde**: ConcurrentVec implements `Serialize` and `Deserialize` traits; the "serde" feature needs to be added when required. You may find de-serialization examples in the corresponding [test file](https://github.com/orxfun/orx-concurrent-vec/blob/main/tests/serde.rs).
+
 ## Contributing
 
 Contributions are welcome! If you notice an error, have a question or think something could be added or improved, please open an [issue](https://github.com/orxfun/orx-concurrent-vec/issues/new) or create a PR.

--- a/src/common_traits/mod.rs
+++ b/src/common_traits/mod.rs
@@ -4,3 +4,6 @@ mod eq;
 mod from_iter;
 mod index;
 mod into_iter;
+
+#[cfg(feature = "serde")]
+mod serde;

--- a/src/common_traits/serde.rs
+++ b/src/common_traits/serde.rs
@@ -1,0 +1,104 @@
+use crate::{ConcurrentElement, ConcurrentVec};
+use core::marker::PhantomData;
+use orx_concurrent_option::ConcurrentOption;
+use orx_fixed_vec::IntoConcurrentPinnedVec;
+use serde::{de::Visitor, ser::SerializeSeq, Deserialize, Serialize};
+
+impl<T, P> Serialize for ConcurrentVec<T, P>
+where
+    P: IntoConcurrentPinnedVec<ConcurrentElement<T>>,
+    T: Serialize,
+{
+    /// Serializes the concurrent vector elements as a sequence.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use orx_concurrent_vec::*;
+    ///
+    /// let empty_vec = ConcurrentVec::<String>::new();
+    /// let json = serde_json::to_string(&empty_vec).unwrap();
+    /// assert_eq!(json, "[]");
+    ///
+    /// let vec = ConcurrentVec::new();
+    /// for i in 0..7 {
+    ///     vec.push(i.to_string());
+    /// }
+    /// let json = serde_json::to_string(&vec).unwrap();
+    /// assert_eq!(json, "[\"0\",\"1\",\"2\",\"3\",\"4\",\"5\",\"6\"]");
+    /// ```
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut seq = serializer.serialize_seq(Some(self.len()))?;
+        for element in self.iter() {
+            element.map(|x| seq.serialize_element(x))?;
+        }
+        seq.end()
+    }
+}
+
+struct ConcurrentVecDeserializer<T, P>
+where
+    P: IntoConcurrentPinnedVec<ConcurrentElement<T>>,
+{
+    phantom: PhantomData<(T, P)>,
+}
+
+impl<'de, T, P> Visitor<'de> for ConcurrentVecDeserializer<T, P>
+where
+    P: IntoConcurrentPinnedVec<ConcurrentElement<T>> + Default,
+    T: Deserialize<'de>,
+{
+    type Value = ConcurrentVec<T, P>;
+
+    fn expecting(&self, formatter: &mut alloc::fmt::Formatter) -> alloc::fmt::Result {
+        formatter.write_str("Expecting the sequence of elements.")
+    }
+
+    fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+    where
+        A: serde::de::SeqAccess<'de>,
+    {
+        let mut pinned = P::default();
+        while let Some(x) = seq.next_element::<T>()? {
+            pinned.push(ConcurrentElement(ConcurrentOption::some(x)));
+        }
+        Ok(ConcurrentVec::new_from_pinned(pinned))
+    }
+}
+
+impl<'de, T, P> Deserialize<'de> for ConcurrentVec<T, P>
+where
+    P: IntoConcurrentPinnedVec<ConcurrentElement<T>> + Default,
+    T: Deserialize<'de>,
+{
+    /// Deserializes a sequence as a concurrent vector.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use orx_concurrent_vec::*;
+    ///
+    /// let json = "[]";
+    /// let result: Result<ConcurrentVec<String>, _> = serde_json::from_str(json);
+    /// assert!(result.is_ok());
+    /// let empty_vec = result.unwrap();
+    /// assert!(empty_vec.is_empty());
+    ///
+    /// let json = "[0, 1, 2, 3, 4, 5, 6]";
+    /// let result: Result<ConcurrentVec<u64>, _> = serde_json::from_str(json);
+    /// assert!(result.is_ok());
+    /// let vec = result.unwrap();
+    /// assert_eq!(vec, [0, 1, 2, 3, 4, 5, 6]);
+    /// ```
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_seq(ConcurrentVecDeserializer {
+            phantom: PhantomData,
+        })
+    }
+}

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -1,0 +1,31 @@
+#![cfg(feature = "serde")]
+use orx_concurrent_vec::*;
+
+#[test]
+fn serialize() {
+    let empty_vec = ConcurrentVec::<String>::new();
+    let json = serde_json::to_string(&empty_vec).unwrap();
+    assert_eq!(json, "[]");
+
+    let vec = ConcurrentVec::new();
+    for i in 0..7 {
+        vec.push(i.to_string());
+    }
+    let json = serde_json::to_string(&vec).unwrap();
+    assert_eq!(json, "[\"0\",\"1\",\"2\",\"3\",\"4\",\"5\",\"6\"]");
+}
+
+#[test]
+fn deserialize() {
+    let json = "[]";
+    let result: Result<ConcurrentVec<String>, _> = serde_json::from_str(json);
+    assert!(result.is_ok());
+    let empty_vec = result.unwrap();
+    assert!(empty_vec.is_empty());
+
+    let json = "[0, 1, 2, 3, 4, 5, 6]";
+    let result: Result<ConcurrentVec<u64>, _> = serde_json::from_str(json);
+    assert!(result.is_ok());
+    let vec = result.unwrap();
+    assert_eq!(vec, [0, 1, 2, 3, 4, 5, 6]);
+}


### PR DESCRIPTION
* Serialize & Deserialize are implemented for ConcurrentVec. The concurrent vector is represented as a regular sequence.
* These implementations are available only through opt-in feature "serde".
* Example usage can be found in the corresponding [test file](https://github.com/orxfun/orx-concurrent-vec/blob/serde-feature/tests/serde.rs).
