### PR TITLE
Upgrade pinned vec dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-concurrent-vec"
-version = "3.7.0"
+version = "3.8.0"
 edition = "2024"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "A thread-safe, efficient and lock-free vector allowing concurrent grow, read and update operations."
@@ -12,22 +12,22 @@ categories = ["data-structures", "concurrency", "rust-patterns", "no-std"]
 [dependencies]
 orx-pseudo-default = { version = "2.1.0", default-features = false }
 orx-pinned-vec = { version = "3.17.0", default-features = false }
-orx-fixed-vec = { version = "3.18.0", default-features = false }
-orx-split-vec = { version = "3.18.0", default-features = false }
-orx-pinned-concurrent-col = { version = "2.14.0", default-features = false }
+orx-fixed-vec = { version = "3.19.0", default-features = false }
+orx-split-vec = { version = "3.19.0", default-features = false }
+orx-pinned-concurrent-col = { version = "2.15.0", default-features = false }
 orx-concurrent-option = "1.5.0"
 serde = { version = "1.0.219", optional = true, default-features = false }
 
 [dev-dependencies]
 append-only-vec = "0.1.7"
-boxcar = "0.2.11"
-clap = { version = "4.5.35", features = ["derive"] }
-criterion = "0.5.1"
+boxcar = "0.2.14"
+clap = { version = "4.5.47", features = ["derive"] }
+criterion = "0.7.0"
 orx-iterable = { version = "1.3.0", default-features = false }
-rand = "0.9.0"
+rand = "0.9.2"
 rand_chacha = "0.9.0"
-rayon = "1.10.0"
-serde_json = { version = "1.0.140", default-features = false, features = [
+rayon = "1.11.0"
+serde_json = { version = "1.0.143", default-features = false, features = [
     "std",
 ] }
 test-case = "3.3.1"

--- a/benches/collect_with_extend.rs
+++ b/benches/collect_with_extend.rs
@@ -1,6 +1,7 @@
 use append_only_vec::AppendOnlyVec;
-use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use orx_concurrent_vec::*;
+use std::hint::black_box;
 
 #[allow(dead_code)]
 #[derive(Clone, Copy)]

--- a/benches/collect_with_push.rs
+++ b/benches/collect_with_push.rs
@@ -1,6 +1,7 @@
 use append_only_vec::AppendOnlyVec;
-use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use orx_concurrent_vec::*;
+use std::hint::black_box;
 
 #[allow(dead_code)]
 #[derive(Clone, Copy)]

--- a/src/concurrent_slice/slice.rs
+++ b/src/concurrent_slice/slice.rs
@@ -111,7 +111,7 @@ where
     /// let sub_slice = slice.slice(1..3);
     /// assert_eq!(&sub_slice, &[2, 3]);
     /// ```
-    pub fn slice<R: RangeBounds<usize>>(&self, range: R) -> ConcurrentSlice<T, P> {
+    pub fn slice<R: RangeBounds<usize>>(&self, range: R) -> ConcurrentSlice<'_, T, P> {
         let [a, b] = orx_pinned_vec::utils::slice::vec_range_limits(&range, Some(self.len()));
         let len = b - a;
         ConcurrentSlice::new(self.vec, self.a + a, len)

--- a/src/concurrent_slice/split.rs
+++ b/src/concurrent_slice/split.rs
@@ -60,7 +60,7 @@ where
     /// assert_eq!(a, &2);
     /// assert_eq!(b, []);
     /// ```
-    pub fn split_first(&self) -> Option<(&ConcurrentElement<T>, ConcurrentSlice<T, P>)> {
+    pub fn split_first(&self) -> Option<(&ConcurrentElement<T>, ConcurrentSlice<'_, T, P>)> {
         match self.get(0) {
             Some(a) => {
                 let b = self.slice(1..self.len());
@@ -94,7 +94,7 @@ where
     /// assert_eq!(a, &2);
     /// assert_eq!(b, []);
     /// ```
-    pub fn split_last(&self) -> Option<(&ConcurrentElement<T>, ConcurrentSlice<T, P>)> {
+    pub fn split_last(&self) -> Option<(&ConcurrentElement<T>, ConcurrentSlice<'_, T, P>)> {
         let len = self.len();
         match len {
             0 => None,

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -26,7 +26,7 @@ where
         i: usize,
         initial_state: StateU8,
         success_state: StateU8,
-    ) -> Option<MutHandle<T>> {
+    ) -> Option<MutHandle<'_, T>> {
         match i < self.len() {
             true => unsafe {
                 self.core

--- a/src/split.rs
+++ b/src/split.rs
@@ -24,7 +24,7 @@ where
     /// assert_eq!(a, [0, 1, 2]);
     /// assert_eq!(b, [3, 4, 5, 6, 7]);
     /// ```
-    pub fn split_at(&self, mid: usize) -> (ConcurrentSlice<T, P>, ConcurrentSlice<T, P>) {
+    pub fn split_at(&self, mid: usize) -> (ConcurrentSlice<'_, T, P>, ConcurrentSlice<'_, T, P>) {
         assert!(mid <= self.len());
         (self.slice(0..mid), self.slice(mid..))
     }
@@ -52,7 +52,7 @@ where
     /// assert_eq!(a, &2);
     /// assert_eq!(b, []);
     /// ```
-    pub fn split_first(&self) -> Option<(&ConcurrentElement<T>, ConcurrentSlice<T, P>)> {
+    pub fn split_first(&self) -> Option<(&ConcurrentElement<T>, ConcurrentSlice<'_, T, P>)> {
         match self.get(0) {
             Some(a) => {
                 let b = self.slice(1..self.len());
@@ -85,7 +85,7 @@ where
     /// assert_eq!(a, &2);
     /// assert_eq!(b, []);
     /// ```
-    pub fn split_last(&self) -> Option<(&ConcurrentElement<T>, ConcurrentSlice<T, P>)> {
+    pub fn split_last(&self) -> Option<(&ConcurrentElement<T>, ConcurrentSlice<'_, T, P>)> {
         let len = self.len();
         match len {
             0 => None,
@@ -122,7 +122,7 @@ where
     pub fn chunks(
         &self,
         chunk_size: usize,
-    ) -> impl ExactSizeIterator<Item = ConcurrentSlice<T, P>> {
+    ) -> impl ExactSizeIterator<Item = ConcurrentSlice<'_, T, P>> {
         assert!(chunk_size > 0);
 
         let len = self.len();

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -214,7 +214,7 @@ where
     /// let sub_slice = slice.slice(1..3);
     /// assert_eq!(&sub_slice, &[2, 3]);
     /// ```
-    pub fn slice<R: RangeBounds<usize>>(&self, range: R) -> ConcurrentSlice<T, P> {
+    pub fn slice<R: RangeBounds<usize>>(&self, range: R) -> ConcurrentSlice<'_, T, P> {
         let [a, b] = orx_pinned_vec::utils::slice::vec_range_limits(&range, Some(self.len()));
         let len = b - a;
         ConcurrentSlice::new(self, a, len)
@@ -238,7 +238,7 @@ where
     /// let slice = vec.as_slice();
     /// assert_eq!(&slice, &[0, 1, 2, 3, 4]);
     /// ```
-    pub fn as_slice(&self) -> ConcurrentSlice<T, P> {
+    pub fn as_slice(&self) -> ConcurrentSlice<'_, T, P> {
         self.slice(0..self.len())
     }
 


### PR DESCRIPTION
With new pinned vectors, it upgrades to latest concurrent iterator version, enabling new parallelization features.